### PR TITLE
Remove RoundTable (again)

### DIFF
--- a/resources/views/pages/impressum.blade.php
+++ b/resources/views/pages/impressum.blade.php
@@ -6,8 +6,8 @@
     @endcomponent
 
     <p>Diese Website ist ein Projekt von:</p>
-    <p>Verein Round Table 25 Winterthur</p>
-    <p>c/o Simon Moser</p>
-    <p>Kirchplatz 1</p>
+    <p>Verein für Menschen</p>
+    <p>c/o Kai Frehner</p>
+    <p>Nelkenstrasse 6</p>
     <p>8400 Winterthur</p>
 @endsection

--- a/resources/views/pages/privacy.blade.php
+++ b/resources/views/pages/privacy.blade.php
@@ -48,7 +48,7 @@
         gelöscht.</p>
 
     <x-page-subtitle>Verantwortliche:r für die Datenverarbeitung</x-page-subtitle>
-    <p>Verantwortlich für die Datenverarbeitung ist der Verein <strong>Round Table 25 Winterthur</strong>. Bei Fragen
+    <p>Verantwortlich für die Datenverarbeitung ist der <strong>Verein für Menschen</strong>. Bei Fragen
         zur
         Datenverarbeitung kannst du dich an folgende Adresse wenden:</p>
     <div class="m-sm">


### PR DESCRIPTION
This pull request updates the organization name and contact details across the website to reflect a change in ownership or representation. The most important changes include updates to the "Impressum" and "Privacy" pages.

### Updates to organization details:

* [`resources/views/pages/impressum.blade.php`](diffhunk://#diff-e73a46cb57cb71f83b726fda9cd819c6cf16afe622d5fa3166205e8081aa9a95L9-R11): Updated the organization name from "Verein Round Table 25 Winterthur" to "Verein für Menschen," along with changes to the contact person's name and address.
* [`resources/views/pages/privacy.blade.php`](diffhunk://#diff-9ba6c905289b97ebfd40b802310d52c7ee0a8e4b3b5e1c5312f2e885a0f5dc6dL51-R51): Updated the organization name in the privacy policy section to "Verein für Menschen" to align with the new representation.Introduced `DonatorFactory` and `DonationFactory` for generating mock data. Updated `Donator` and `Donation` models to use the `HasFactory` trait. Enhanced database seeder to include example data generation for local environments.