### PR TITLE
Add "Vereinsmitglied werden" link for guests

### DIFF
--- a/app/Components/PublicMenu.php
+++ b/app/Components/PublicMenu.php
@@ -29,11 +29,6 @@ class PublicMenu extends Component
             "route" => "become-donator",
             "active" => false,
         ],
-        [
-            "name" => "Vereinsmitglied werden",
-            "route" => "association",
-            "active" => false,
-        ],
     ];
 
     public function mount(): void

--- a/resources/views/components/public-menu.blade.php
+++ b/resources/views/components/public-menu.blade.php
@@ -34,6 +34,12 @@
                     {{ $item['name'] }}
                 </a>
             @endforeach
+            @guest
+                <a href="{{ route("association") }}" wire:navigate
+                   class="text-sm leading-6 grow hover:text-hfm-light text-hfm-dark dark:text-hfm-white font-normal flex flex-row space-x-2">
+                    <span>Vereinsmitglied werden</span>
+                </a>
+            @endguest
             @auth
                 <a
                     href="{{ route("admin.dashboard") }}"
@@ -125,6 +131,15 @@
                                 {{ $item['name'] }}
                             </a>
                         @endforeach
+                        @guest
+                            <a
+                                href="{{ route("association") }}"
+                                wire:navigate
+                                class="-mx-3 block rounded-lg px-3 py-2 text-base font-medium leading-7 hover:text-hfm-light text-hfm-dark dark:text-hfm-white"
+                            >
+                                Vereinsmitglied werden
+                            </a>
+                        @endguest
                         @auth
                             <a
                                 href="{{ route("admin.dashboard") }}"


### PR DESCRIPTION
### Summary
This pull request reintroduces the "Vereinsmitglied werden" link in the navigation menu. The link is now exclusively displayed for guest users on both desktop and mobile views. Additionally, the redundant static menu configuration in `PublicMenu.php` has been removed to streamline dynamic link handling.

### Changes
- Added "Vereinsmitglied werden" link for guest users.
- Updated dynamic link handling and removed redundant static configuration.