### PR TITLE
Replace FluxUI checkbox with WireUI toggle for privacy consent

### DIFF
--- a/resources/views/forms/become-athlete-form.blade.php
+++ b/resources/views/forms/become-athlete-form.blade.php
@@ -87,14 +87,12 @@
                    placeholder="Ich freu mich druf. Bin zwar nöd mega sportlich, aber das isch ja egal. Hauptsach es chunnt e gueti Summe zäme!"
                    wire:model.blur="comment" autocomplete="off" />
 
-    <span class="sm:col-span-2 flex flex-row space-x-sm items-center">
-            <flux:checkbox wire:model.bool="privacy" autocomplete="off" />
-            <span class="text-md">
-                Ich bin damit einverstanden, dass meine Daten für die Organisation des Anlasses verwendet werden.
+    <span class="sm:col-span-2">
+            <x-toggle wire:model.bool.live="privacy"
+                      label="Ich bin damit einverstanden, dass meine Daten für die Organisation des Anlasses verwendet werden." />
                 <button type="button" wire:click="showPrivacyInfo"
-                        class="text-hfm-red dark:text-hfm-lightred underline">Was heisst das?</button>
-            </span>
-        </span>
+                        class="text-xs underline mt-xs">Was heisst das?</button>
+    </span>
 
     <x-honey />
     <flux:button


### PR DESCRIPTION
### Description
- Replaced the FluxUI checkbox with a WireUI toggle for privacy consent due to an update issue in the FluxUI component.
- Implemented as a temporary hotfix to resolve the bug without requiring an update to FluxUI. 

### Context
- The FluxUI component demonstrated a bug where the attached field was not being updated.
- WireUI was used as an alternative due to version constraints preventing an upgrade of FluxUI.

### Related Issues
- Fixes #11