### PR TITLE
Refactor database migration command in deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,7 +105,7 @@ jobs:
             $COMPOSER_BIN install --no-dev --optimize-autoloader || { echo "Composer install failed! Exiting."; exit 1; }
 
             echo "Running database migrations..."
-            $PHP_BIN artisan migrate:fresh --seed --force || { echo "Migrations failed! Exiting."; exit 1; }
+            $PHP_BIN artisan migrate --force || { echo "Migrations failed! Exiting."; exit 1; }
 
             echo "Optimizing application..."
             $PHP_BIN artisan optimize || { echo "Optimization failed! Exiting."; exit 1; }


### PR DESCRIPTION
This pull request includes a small change to the deployment workflow in `.github/workflows/deploy.yml`. The change modifies the database migration command to use `migrate` instead of `migrate:fresh --seed`.

This means that the database now is **not reset anymore** on new deployments.

I.e.
# $${\color{red}\text{The App is now in Production}}$$

@KaiFrehner 