### PR TITLE
Enable SQLite database for PHPUnit testing

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -22,8 +22,8 @@
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>
-        <!-- <env name="DB_CONNECTION" value="sqlite"/> -->
-        <!-- <env name="DB_DATABASE" value=":memory:"/> -->
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value="database/testing.sqlite"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>


### PR DESCRIPTION
Uncommented and updated the `DB_CONNECTION` and `DB_DATABASE` environment variables in `phpunit.xml` to configure SQLite for tests. This ensures a consistent and isolated database environment during test execution.

### Implementation note
create the file `database/testing.sqlite`
```bash
touch database/testing.sqlite
```