### PR TITLE
Display Fixes: Add 'public_id' and formatted 'created_at' enhancements

### DIFF
--- a/app/Components/AdminAssociationMemberTable.php
+++ b/app/Components/AdminAssociationMemberTable.php
@@ -4,6 +4,7 @@ namespace App\Components;
 
 use App\Models\AssociationMember;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Livewire\Attributes\On;
 use PowerComponents\LivewirePowerGrid\Button;
 use PowerComponents\LivewirePowerGrid\Column;
@@ -65,7 +66,8 @@ class AdminAssociationMemberTable extends PowerGridComponent
 
     public function fields(): PowerGridFields
     {
-        return PowerGrid::fields();
+        return PowerGrid::fields()
+            ->add('created_at_formatted', fn ($athlete) => Carbon::parse($athlete->created_at)->format('d.m.Y'));
     }
 
     public function columns(): array

--- a/app/Components/BecomeDonatorForm.php
+++ b/app/Components/BecomeDonatorForm.php
@@ -256,7 +256,7 @@ class BecomeDonatorForm extends Component
         $this->athletes = Athlete::query()
             ->where('verified', true)
             ->orderBy('first_name')
-            ->get(['id', 'first_name', 'last_name', 'partner_id']) // fetch real columns only
+            ->get(['id', 'first_name', 'last_name', 'partner_id', 'public_id']) // fetch real columns only
             ->each->append(['privacy_name', 'public_id_string'])  // append computed attributes
             ->toArray();
 


### PR DESCRIPTION
This pull request introduces updates to enhance data handling and formatting in two components: `AdminAssociationMemberTable` and `BecomeDonatorForm`. The changes include adding a new date formatting feature and extending the data fetched for athletes.

### Enhancements to `AdminAssociationMemberTable`:

* Added the `Carbon` library for date handling (`app/Components/AdminAssociationMemberTable.php`).
* Updated the `fields` method to include a new formatted `created_at` field using `Carbon` for date formatting (`app/Components/AdminAssociationMemberTable.php`).

### Enhancements to `BecomeDonatorForm`:

* Modified the `mount` method to fetch an additional `public_id` column for athletes and append it as a computed attribute (`app/Components/BecomeDonatorForm.php`).