### PR TITLE
Feat/association member message preview

### DIFF
--- a/app/Components/AdminAssociationMemberMessage.php
+++ b/app/Components/AdminAssociationMemberMessage.php
@@ -112,6 +112,13 @@ class AdminAssociationMemberMessage extends Component
         // validate the form
         $this->validate();
 
+        // Validate that $arr_id exists in $this->selected_members
+        if (! array_key_exists($arr_id, $this->selected_members)) {
+            Flux::toast(text: 'Es ist ein Fehler aufgetreten.', heading: 'Fehler', variant: 'danger');
+
+            return;
+        }
+
         $this->message_preview_id = $arr_id;
 
         // get the $arr_id member from the array

--- a/resources/views/components/admin/association-member-message.blade.php
+++ b/resources/views/components/admin/association-member-message.blade.php
@@ -88,23 +88,18 @@
             <flux:accordion.item>
                 <flux:accordion.heading>Raw HTML</flux:accordion.heading>
                 <flux:accordion.content class="space-y-3">
-                    <flux:textarea
-                        wire:model.live.debounce="message_preview_html"
-                        rows="10"
-                        class="font-mono"
-                        readonly
-                    />
+                    <pre class="font-mono whitespace-pre-wrap">{{ $this->message_preview_html }}</pre>
                 </flux:accordion.content>
             </flux:accordion.item>
         </flux:accordion>
         <flux:button.group>
             <flux:button
                 icon="arrow-left"
-                wire:click="showMessagePreview( {{ $this->message_preview_id - 1 }})"
+                wire:click="showMessagePreview({{ $this->message_preview_id - 1 }})"
                 :disabled="$this->message_preview_id < 1">
                 Zurück
             </flux:button>
-            <flux:button icon="arrow-right" wire:click="showMessagePreview( {{ $this->message_preview_id + 1 }})"
+            <flux:button icon="arrow-right" wire:click="showMessagePreview({{ $this->message_preview_id + 1 }})"
                          :disabled="$this->message_preview_id >= count($this->selected_members) - 1">
                 Weiter
             </flux:button>


### PR DESCRIPTION
This pull request introduces a message preview feature and improves the message-sending workflow in the `AdminAssociationMemberMessage` component. Key changes include adding support for previewing messages with placeholders, introducing modals for message previews and confirmation dialogs, and updating the UI to handle these new features.

### Message Preview Functionality:
* Added `message_preview_html` and `message_preview_id` properties to the `AdminAssociationMemberMessage` class to store the rendered message preview and track the selected member for preview purposes. (`app/Components/AdminAssociationMemberMessage.php`, [app/Components/AdminAssociationMemberMessage.phpR40-R45](diffhunk://#diff-c4b224d8a1916e6e581c60d62eb6b32ca12d7ec71ff7940ed08836150202eac4R40-R45))
* Implemented the `showMessagePreview` method to render a message preview with placeholders replaced and dangerous HTML tags sanitized. This method also triggers a modal to display the preview. (`app/Components/AdminAssociationMemberMessage.php`, [app/Components/AdminAssociationMemberMessage.phpR110-R140](diffhunk://#diff-c4b224d8a1916e6e581c60d62eb6b32ca12d7ec71ff7940ed08836150202eac4R110-R140))
* Updated the Blade template to include a new "Preview" button that calls the `showMessagePreview` method and a modal to display the rendered and raw HTML of the message preview. Navigation buttons allow switching between previews for different members. (`resources/views/components/admin/association-member-message.blade.php`, [resources/views/components/admin/association-member-message.blade.phpR64-R133](diffhunk://#diff-74fe51a03ee57d9381d3298bc6b2d82f436921c5a4f373f9ddfebde9c8220291R64-R133))

### Enhanced Message-Sending Workflow:
* Added a `sendMessageRequest` method to handle message-sending logic. If multiple members are selected, it shows a confirmation modal; otherwise, it sends the message directly. (`app/Components/AdminAssociationMemberMessage.php`, [app/Components/AdminAssociationMemberMessage.phpR110-R140](diffhunk://#diff-c4b224d8a1916e6e581c60d62eb6b32ca12d7ec71ff7940ed08836150202eac4R110-R140))
* Updated the Blade template to include a confirmation modal for sending messages to multiple members, ensuring users are aware of the recipients before proceeding. (`resources/views/components/admin/association-member-message.blade.php`, [resources/views/components/admin/association-member-message.blade.phpR64-R133](diffhunk://#diff-74fe51a03ee57d9381d3298bc6b2d82f436921c5a4f373f9ddfebde9c8220291R64-R133))