### PR TITLE
feat: add FAQ section with event details and participant instructions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Start Laravel and Run E2E Tests
         run: |
           set -euo pipefail
-          php artisan serve --host=127.0.0.1 --port=8000 &
+          php artisan serve --host=127.0.0.1 --port=8000 --silent &
           npx wait-on http://127.0.0.1:8000
           npx playwright test --reporter=html
         env:
@@ -91,17 +91,6 @@ jobs:
         with:
           name: playwright-report
           path: playwright-report/
-          if-no-files-found: ignore
-          retention-days: 7
-
-      - name: Upload Playwright Artifacts (PR only)
-        if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-artifacts
-          path: |
-            e2e-results/
-            test-results/
           if-no-files-found: ignore
           retention-days: 7
 

--- a/database/factories/AthleteFactory.php
+++ b/database/factories/AthleteFactory.php
@@ -34,4 +34,11 @@ class AthleteFactory extends Factory
             'verified' => fake()->boolean(80),
         ];
     }
+
+    public function verified(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'verified' => true,
+        ]);
+    }
 }

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -72,7 +72,8 @@ class DatabaseSeeder extends Seeder
 
         // create example data
         if (config('app.env') === 'local') {
-            Athlete::factory(10)->create();
+            Athlete::factory(5)->create();
+            Athlete::factory(5)->verified()->create();
             Donator::factory(10)->create();
             Donation::factory(10)->create();
         }

--- a/resources/views/pages/questions-and-answers.blade.php
+++ b/resources/views/pages/questions-and-answers.blade.php
@@ -80,7 +80,7 @@
 
         <x-faq-question-answer>
             <x-slot:question>Gibt es Verpflegung vor Ort?</x-slot:question>
-            Es wird Getränke und Snacks geben. Für die Sportler:innen gibt es zudem eine Verpflegungsstation beim
+            Es gibt nur Verpflegung für Sportler:innen. Es wird Getränke (Wasser und isotonisches Getränk) und Snacks geben. Die Verpflegungsstation befindet sich beim
             Start/Ziel des Rundkurses.
         </x-faq-question-answer>
 
@@ -168,6 +168,30 @@
             <x-slot:question>Ich bin nicht besonders sportlich. Kann ich trotzdem teilnehmen?</x-slot:question>
             Ja, der Anlass ist für alle geeignet. Du kannst so viele Runden laufen oder fahren, wie du möchtest. Es
             geht nicht darum, wer am besten ist, sondern darum, gemeinsam Spenden zu sammeln.
+        </x-faq-question-answer>
+
+        <x-faq-question-answer>
+            <x-slot:question>Wie ist der Ablauf am Anlass?</x-slot:question>
+            <ul class="list-disc text-sm list-inside space-y-xs">
+                <li>
+                    Ab <strong>12:30 Uhr</strong> sind die Startnummern im Rundenbüro abholbereit. Das Rundenbüro befindet sich gut Sichtbar beim Start/Ziel, direkt for der Brühlgut Stiftung.
+                </li>
+                <li>
+                    Die Startnummer muss gut sichtbar auf der Vorderseite deines Trikots/Fahrrads befestigt werden. Es stehen dafür Sicherheitsnadeln bereit.
+                </li>
+                <li>
+                    Um <strong>13:00 Uhr</strong> gibt es einen gemeinsamen Start mit allen Sportler:innen, die dann bereits bereit sind.
+                </li>
+                <li>
+                    Du hast zwischen 13 Uhr und 18 Uhr Zeit, die Runden zurückzulegen. Du musst auch nicht bereits um 13 Uhr starten.
+                </li>
+                <li>
+                    Wir werden deine zurückgelegten Runden zählen. Aber es hilft, wenn du dies auch tust.
+                </li>
+                <li>
+                    Sobald du fertig bist, kannst du nochmals ins Rundenbüro kommen. Dort gleichen wir die Anzahl Runden ab und du bekommst vielleicht noch eine Kleinigkeit.
+                </li>
+            </ul>
         </x-faq-question-answer>
 
     </dl>

--- a/resources/views/pages/questions-and-answers.blade.php
+++ b/resources/views/pages/questions-and-answers.blade.php
@@ -174,10 +174,10 @@
             <x-slot:question>Wie ist der Ablauf am Anlass?</x-slot:question>
             <ul class="list-disc text-sm list-inside space-y-xs">
                 <li>
-                    Ab <strong>12:30 Uhr</strong> sind die Startnummern im Rundenbüro abholbereit. Das Rundenbüro befindet sich gut Sichtbar beim Start/Ziel, direkt for der Brühlgut Stiftung.
+                    Ab <strong>12:30 Uhr</strong> sind die Startnummern im Rundenbüro abholbereit. Das Rundenbüro befindet sich gut sichtbar beim Start/Ziel, direkt vor der Brühlgut Stiftung.
                 </li>
                 <li>
-                    Die Startnummer muss gut sichtbar auf der Vorderseite deines Trikots/Fahrrads befestigt werden. Es stehen dafür Sicherheitsnadeln bereit.
+                    Die Startnummer muss gut sichtbar auf der Vorderseite deines Trikots befestigt werden. Es stehen dafür Sicherheitsnadeln bereit.
                 </li>
                 <li>
                     Um <strong>13:00 Uhr</strong> gibt es einen gemeinsamen Start mit allen Sportler:innen, die dann bereits bereit sind.


### PR DESCRIPTION
This pull request updates the FAQ section on the `questions-and-answers.blade.php` page to clarify the details about on-site catering and to provide a new FAQ entry outlining the event schedule for participants.

**Content updates to FAQ:**

* Clarified that catering is only available for athletes, specifying the types of drinks (water and isotonic) and snacks, and noted the location of the refreshment station at the start/finish area.

**Addition of event schedule information:**

* Added a new FAQ entry detailing the event day schedule, including start number pickup, start procedure, timing, round counting, and finishing process for athletes.