### PR TITLE
Remove individual athlete results and simplify interface

### DIFF
--- a/app/Components/Results.php
+++ b/app/Components/Results.php
@@ -20,11 +20,6 @@ class Results extends Component
      */
     public array $totals = [];
 
-    /**
-     * @var array<int, array<string, string>>
-     */
-    public array $athletes = [];
-
     public function mount(DonationService $donationService): void
     {
         // Compute a version string based on the latest updated_at timestamps
@@ -33,7 +28,7 @@ class Results extends Component
               (select max(updated_at) from athletes)  as a,
               (select max(updated_at) from donations) as d
         ');
-        $version = ($row->a ?? '0').'|'.($row->d ?? '0');
+        $version = hash('sha256', ($row->a ?? '0').($row->d ?? '0'));
         $cacheKey = 'components.results.data.'.$version;
 
         $data = Cache::remember($cacheKey, now()->addHour(), function () use ($donationService): array {
@@ -41,7 +36,6 @@ class Results extends Component
         });
 
         $this->totals = $data['totals'];
-        $this->athletes = $data['athletes'];
     }
 
     public function render(): ViewContract
@@ -54,7 +48,7 @@ class Results extends Component
      * Collect and prepare all data for the component.
      * Ensures a single initial athletes query including relations (donations, partner, sportType).
      *
-     * @return array{totals: array<string, mixed>, athletes: array<int, array<string, string>>}
+     * @return array{totals: array<string, mixed>}
      */
     protected function collectData(DonationService $donationService): array
     {
@@ -114,30 +108,6 @@ class Results extends Component
             }
         }
 
-        // Athletes table data (exclude athletes without completed rounds)
-        $athletes = $allAthletes
-            ->filter(function (Athlete $athlete): bool {
-                return (int) ($athlete->rounds_done ?? 0) > 0;
-            })
-            ->map(function (Athlete $athlete) use ($donationService): array {
-                $donationsActual = $donationService->calculateActualTotalForAthlete($athlete);
-
-                $rounds = (int) ($athlete->rounds_done ?? 0);
-                $roundsFormatted = number_format($rounds, 0, '.', "'");
-                $donationsFormatted = number_format($donationsActual, 2, '.', "'");
-
-                return [
-                    'privacy_name' => $athlete->privacy_name,
-                    'sport_type' => optional($athlete->sportType)->name ?? '—',
-                    'partner' => optional($athlete->partner)->name ?? '—',
-                    'rounds_done' => $roundsFormatted,
-                    'donations_actual' => $donationsFormatted,
-                ];
-            })
-            ->sortBy('privacy_name', SORT_NATURAL | SORT_FLAG_CASE)
-            ->values()
-            ->all();
-
         return [
             'totals' => [
                 'athletes' => $athletesCount,
@@ -147,7 +117,6 @@ class Results extends Component
                 'donations_total' => $donationsTotal,
                 'per_partner' => $perPartner->toArray(),
             ],
-            'athletes' => $athletes,
         ];
     }
 }

--- a/e2e/view-results.spec.mjs
+++ b/e2e/view-results.spec.mjs
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 test.describe("Results page", () => {
     test("renders, shows info notices, and lists individual results", async ({ page }) => {
@@ -6,52 +6,21 @@ test.describe("Results page", () => {
 
         // Ensure network idle and images are loaded (for robust screenshots)
         await page.waitForLoadState("networkidle");
-        await page.waitForFunction(() =>
-            Array.from(document.images).every((img) => img.complete && img.naturalWidth > 0),
-        );
 
         await expect(page.getByRole("heading")).toContainText("Resultate");
 
-        // Screenshot 1: initial page
+        // Screenshot
         const startScreenshot = await page.screenshot({ fullPage: true });
         await test.info().attach("results-start", { body: startScreenshot, contentType: "image/png" });
 
-        // Toggle the two info notices (Hinweis ...)
-        const totalNoticeBtn = page.getByRole("button", { name: "Hinweis zu der" });
-        const singlesNoticeBtn = page.getByRole("button", { name: "Hinweis zu Einzelresultaten" });
-        await expect(totalNoticeBtn).toBeVisible();
-        await expect(singlesNoticeBtn).toBeVisible();
-
-        await totalNoticeBtn.click();
         await expect(page.getByText("Die Angaben der Spenden")).toBeVisible();
 
-        await singlesNoticeBtn.click();
-        await expect(page.getByText("Zu den Einzelresultaten mö")).toBeVisible();
-
         // Some key summary tiles should be visible on the default tab
-        await expect(page.getByText("Sportler:innen")).toBeVisible();
+        await expect(page.getByText("Sportler:innen", { exact: true })).toBeVisible();
         await expect(page.getByText("Spender:innen", { exact: true })).toBeVisible();
         await expect(page.getByText("Absolvierte Runden")).toBeVisible();
         await expect(page.getByText("Höhenmeter überwunden")).toBeVisible();
         await expect(page.getByText("Total Spenden")).toBeVisible();
         await expect(page.getByText("Spenden pro Benefizpartner:in")).toBeVisible();
-
-        // Screenshot 2: after both info notices are expanded
-        await page.waitForLoadState("networkidle");
-        const afterHinweise = await page.screenshot({ fullPage: true });
-        await test.info().attach("results-after-hinweise", { body: afterHinweise, contentType: "image/png" });
-
-        // Go to the Einzelresultate tab and verify expected columns
-        await page.getByRole("tab", { name: "Einzelresultate" }).click();
-        await expect(page.getByText("Name", { exact: true })).toBeVisible();
-        await expect(page.getByText("Sportart")).toBeVisible();
-        await expect(page.getByText("Partner:in", { exact: true })).toBeVisible();
-        await expect(page.getByText("Runden", { exact: true })).toBeVisible();
-        await expect(page.getByText("Spenden", { exact: true })).toBeVisible();
-
-        // Screenshot 3: after switching to the Einzelresultate tab
-        await page.waitForLoadState("networkidle");
-        const afterEinzel = await page.screenshot({ fullPage: true });
-        await test.info().attach("results-after-einzelresultate", { body: afterEinzel, contentType: "image/png" });
     });
 });

--- a/resources/views/components/results.blade.php
+++ b/resources/views/components/results.blade.php
@@ -1,106 +1,67 @@
-    <flux:tab.group>
-        <flux:tabs wire:model="tab">
-            <flux:tab name="resultate">Resultate</flux:tab>
-            <flux:tab name="einzel">Einzelresultate</flux:tab>
-        </flux:tabs>
-
-        <flux:tab.panel name="resultate">
-            <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
-                <flux:card>
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <div class="text-sm">Sportler:innen</div>
-                            <div class="mt-1 text-2xl font-semibold">{{ number_format($totals['athletes'], 0, '.', "'") }}</div>
-                        </div>
-                        <flux:icon name="users" class="size-8" />
-                    </div>
-                </flux:card>
-
-                <flux:card>
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <div class="text-sm">Spender:innen</div>
-                            <div class="mt-1 text-2xl font-semibold">{{ number_format($totals['donors'], 0, '.', "'") }}</div>
-                        </div>
-                        <flux:icon name="heart" class="size-8" />
-                    </div>
-                </flux:card>
-
-                <flux:card>
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <div class="text-sm">Absolvierte Runden</div>
-                            <div class="mt-1 text-2xl font-semibold">{{ number_format($totals['rounds'], 0, '.', "'") }}</div>
-                        </div>
-                        <flux:icon name="flag" class="size-8" />
-                    </div>
-                </flux:card>
-
-                <flux:card>
-                    <div class="flex items-center justify-between">
-                        <div>
-                            <div class="text-sm">Höhenmeter überwunden</div>
-                            <div class="mt-1 text-2xl font-semibold">{{ number_format($totals['elevation_m'], 0, '.', "'") }} m</div>
-                        </div>
-                        <flux:icon name="fire" class="size-8" />
-                    </div>
-                </flux:card>
-
-                <div class="sm:col-span-2">
-                    <flux:card>
-                        <div class="flex items-center justify-between">
-                            <div>
-                                <div class="text-sm">Total Spenden</div>
-                                <div class="mt-1 text-4xl font-semibold tracking-tight">Fr. {{ number_format($totals['donations_total'], 2, '.', "'") }}</div>
-                            </div>
-                            <flux:icon name="banknotes" class="size-10" />
-                        </div>
-
-                        <div class="mt-6">
-                            <div class="mb-3 text-sm font-medium">Spenden pro Benefizpartner:in</div>
-                            <ul class="divide-y divide-gray-200 dark:divide-gray-800">
-                                @forelse ($totals['per_partner'] as $partnerName => $amount)
-                                    <li class="flex items-center justify-between py-2">
-                                        <span>{{ $partnerName }}</span>
-                                        <span class="font-medium">Fr. {{ number_format($amount, 2, '.', "'") }}</span>
-                                    </li>
-                                @empty
-                                    <li class="py-4 text-center text-sm">Noch keine Spenden erfasst.</li>
-                                @endforelse
-                            </ul>
-                        </div>
-                    </flux:card>
-                </div>
+<div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+    <flux:card>
+        <div class="flex items-center justify-between">
+            <div>
+                <div class="text-sm">Sportler:innen</div>
+                <div class="mt-1 text-2xl font-semibold">{{ number_format($totals['athletes'], 0, '.', "'") }}</div>
             </div>
-        </flux:tab.panel>
+            <flux:icon name="users" class="size-8" />
+        </div>
+    </flux:card>
 
-        <flux:tab.panel name="einzel">
+    <flux:card>
+        <div class="flex items-center justify-between">
+            <div>
+                <div class="text-sm">Spender:innen</div>
+                <div class="mt-1 text-2xl font-semibold">{{ number_format($totals['donors'], 0, '.', "'") }}</div>
+            </div>
+            <flux:icon name="heart" class="size-8" />
+        </div>
+    </flux:card>
 
-            <flux:table class="!table-auto">
-                <flux:columns>
-                    <flux:column>Name</flux:column>
-                    <flux:column>Sportart</flux:column>
-                    <flux:column>Partner:in</flux:column>
-                    <flux:column>Runden</flux:column>
-                    <flux:column>Spenden</flux:column>
-                </flux:columns>
+    <flux:card>
+        <div class="flex items-center justify-between">
+            <div>
+                <div class="text-sm">Absolvierte Runden</div>
+                <div class="mt-1 text-2xl font-semibold">{{ number_format($totals['rounds'], 0, '.', "'") }}</div>
+            </div>
+            <flux:icon name="flag" class="size-8" />
+        </div>
+    </flux:card>
 
-                <flux:rows>
-                    @forelse ($athletes as $row)
-                        <flux:row>
-                            <flux:cell>{{ $row['privacy_name'] }}</flux:cell>
-                            <flux:cell>{{ $row['sport_type'] }}</flux:cell>
-                            <flux:cell>{{ $row['partner'] }}</flux:cell>
-                            <flux:cell>{{ $row['rounds_done'] }}</flux:cell>
-                            <flux:cell>Fr. {{ $row['donations_actual'] }}</flux:cell>
-                        </flux:row>
+    <flux:card>
+        <div class="flex items-center justify-between">
+            <div>
+                <div class="text-sm">Höhenmeter überwunden</div>
+                <div class="mt-1 text-2xl font-semibold">{{ number_format($totals['elevation_m'], 0, '.', "'") }} m</div>
+            </div>
+            <flux:icon name="fire" class="size-8" />
+        </div>
+    </flux:card>
+
+    <div class="sm:col-span-2">
+        <flux:card>
+            <div class="flex items-center justify-between">
+                <div>
+                    <div class="text-sm">Total Spenden</div>
+                    <div class="mt-1 text-4xl font-semibold tracking-tight">Fr. {{ number_format($totals['donations_total'], 2, '.', "'") }}</div>
+                </div>
+                <flux:icon name="banknotes" class="size-10" />
+            </div>
+
+            <div class="mt-6">
+                <div class="mb-3 text-sm font-medium">Spenden pro Benefizpartner:in</div>
+                <ul class="divide-y divide-gray-200 dark:divide-gray-800">
+                    @forelse ($totals['per_partner'] as $partnerName => $amount)
+                        <li class="flex items-center justify-between py-2">
+                            <span>{{ $partnerName }}</span>
+                            <span class="font-medium">Fr. {{ number_format($amount, 2, '.', "'") }}</span>
+                        </li>
                     @empty
-                        <flux:row>
-                            <flux:cell colspan="5" class="py-6 text-center text-sm">Noch keine Daten vorhanden.</flux:cell>
-                        </flux:row>
+                        <li class="py-4 text-center text-sm">Noch keine Spenden erfasst.</li>
                     @endforelse
-                </flux:rows>
-            </flux:table>
-
-        </flux:tab.panel>
-    </flux:tab.group>
+                </ul>
+            </div>
+        </flux:card>
+    </div>
+</div>

--- a/resources/views/pages/results.blade.php
+++ b/resources/views/pages/results.blade.php
@@ -9,26 +9,10 @@
         Hier siehst du alle Resultate der diesjährigen Durchführung.
     </div>
 
-    <div class="w-full max-w-2xl mx-auto my-lg">
-    <flux:accordion>
-        <flux:accordion.item>
-            <flux:accordion.heading>Hinweis zu der Spendenberechnung</flux:accordion.heading>
-
-            <flux:accordion.content>
-                Die Angaben der Spenden basieren auf der Annahme, dass alle Spender:innen die Spendenrechnung eins zu eins begleichen. Die Erfahrung zeigt, dass sehr wenige die Rechnung nicht bezahlen und gleichzeitig einige den Rechnungsbetrag aufrunden. Deshalb stimmen die Angaben unten nicht genau mit dem überein, was wir schlussendlich an die Benefizpartner:innen überweisen.
-            </flux:accordion.content>
-        </flux:accordion.item>
-
-        <flux:accordion.item>
-            <flux:accordion.heading>Hinweis zu Einzelresultaten</flux:accordion.heading>
-
-            <flux:accordion.content>
-                Zu den Einzelresultaten möchten wir sagen, dass jede Runde zählt und jede Spende zählt. Wir sind kein kompetitiver Sportanlass und möchten das auch nicht sein. Wir sind ein Spendenanlass. Jede Person, die sich aufrafft und mitmacht ist ein Gewinn. Punkt.
-            </flux:accordion.content>
-        </flux:accordion.item>
-    </flux:accordion>
-    </div>
-
     <livewire:results />
+
+    <div class="w-full max-w-2xl mx-auto text-left sm:text-center my-lg">
+        Die Angaben der Spenden basieren auf der Annahme, dass alle Spender:innen die Spendenrechnung eins zu eins begleichen. Die Erfahrung zeigt, dass sehr wenige die Rechnung nicht bezahlen und gleichzeitig einige den Rechnungsbetrag aufrunden. Deshalb stimmen die Angaben oben nicht genau mit dem überein, was wir schlussendlich an die Benefizpartner:innen überweisen. Wir werden alle Sportler:innen und Spender:innen per Mail informieren, welchen Betrag wir genau überwiesen haben.
+    </div>
 @endsection
 

--- a/tests/Feature/Livewire/ResultsTest.php
+++ b/tests/Feature/Livewire/ResultsTest.php
@@ -11,9 +11,8 @@ use Livewire\Livewire;
 it('renders successfully and shows per-partner section', function () {
     Livewire::test(Results::class)
         ->assertStatus(200)
-        ->assertSee('Resultate')
-        ->assertSee('Einzelresultate')
-        ->assertSee('Spenden pro Benefizpartner:in');
+        ->assertSee('Spenden pro Benefizpartner:in')
+        ->assertDontSee('Einzelresultate');
 });
 
 it('splits "alle zu gleichen Teilen" amount across remaining partners', function () {
@@ -85,7 +84,7 @@ it('splits "alle zu gleichen Teilen" amount across remaining partners', function
         ->assertSee('Fr. 80.00');
 });
 
-it('filters out athletes with zero rounds in the table', function () {
+it('does not expose single athlete results anymore', function () {
     $sportType = SportType::create(['name' => 'Run']);
     $partner = Partner::create(['name' => 'Partner X']);
 
@@ -107,9 +106,7 @@ it('filters out athletes with zero rounds in the table', function () {
 
     Livewire::test(Results::class)
         ->assertStatus(200)
-        ->assertSee('Einzelresultate')
-        // Should show the athlete with > 0 rounds
-        ->assertSee($three->privacy_name)
-        // Should NOT show the athlete with 0 rounds
+        ->assertDontSee('Einzelresultate')
+        ->assertDontSee($three->privacy_name)
         ->assertDontSee($zero->privacy_name);
 });


### PR DESCRIPTION
The "Einzelresultate" tab has been removed from the `Results` component, along with its associated logic. Updates include:

- Simplified UI with the replacement of the accordion info section by a single text block.
- Removed individual athlete data across Blade views and component structure.
- Refactored `Results` to streamline data handling.
- Adjusted associated Livewire tests and E2E test (`view-results.spec.mjs`) to align with the updated interface while removing obsolete checks.