### PR TITLE
ci: fix deploy workflow-call permissions and artifact action versions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,9 @@ jobs:
   tests:
     uses: ./.github/workflows/tests.yml
     secrets: inherit
+    permissions:
+      contents: write
+      pull-requests: write
 
   deploy:
     name: Deploy to Server

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload Playwright Report (PR only)
         if: ${{ github.event_name == 'pull_request' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report
           path: playwright-report/
@@ -106,7 +106,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download Playwright Report
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: playwright-report
           path: site


### PR DESCRIPTION
This PR fixes a deployment workflow validation failure caused by insufficient permissions on the reusable tests workflow call, so deploys on main can run again. It also updates artifact upload and download actions used by E2E report publishing to current major versions.

## Details

- [deploy.yml](https://github.com/fuermenschen/hfm/blob/ci/fix-workflow-permissions-and-artifact-actions/.github/workflows/deploy.yml) - grants the tests reusable workflow job the required contents and pull request permissions for nested e2e-tests.
- [e2e.yml](https://github.com/fuermenschen/hfm/blob/ci/fix-workflow-permissions-and-artifact-actions/.github/workflows/e2e.yml) - updates actions/upload-artifact to v7 and actions/download-artifact to v8 for Playwright report handling.
