### PR TITLE
Add scheduled cleanup for stale Playwright reports on gh-pages

### DIFF
--- a/.github/workflows/cleanup-playwright-reports.yml
+++ b/.github/workflows/cleanup-playwright-reports.yml
@@ -4,11 +4,6 @@ on:
   schedule:
     - cron: '0 3 * * 1'
   workflow_dispatch:
-    inputs:
-      days:
-        description: 'Remove pr-* directories where the PR was merged/closed more than this many days ago'
-        required: false
-        default: '14'
 
 permissions:
   contents: write
@@ -31,11 +26,11 @@ jobs:
       - name: Remove stale pr-* directories
         id: cleanup
         env:
-          DAYS: ${{ inputs.days || '14' }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           REMOVED=0
+          DAYS=14
           cutoff_epoch=$(date -d "${DAYS} days ago" '+%s')
 
           for dir in pr-*/; do
@@ -50,13 +45,17 @@ jobs:
               continue
             fi
 
-            pr_data=$(gh pr view "$pr_number" --json mergedAt,closedAt,state --repo "${{ github.repository }}" 2>/dev/null || echo '{}')
-
-            if [ -z "$pr_data" ] || [ "$pr_data" = "{}" ]; then
-              echo "Removing $dir (PR #$pr_number not found)"
-              rm -rf "$dir"
-              REMOVED=$((REMOVED + 1))
-              continue
+            if ! pr_data=$(gh pr view "$pr_number" --json mergedAt,closedAt,state --repo "${{ github.repository }}" 2>/dev/null); then
+              gh_exit=$?
+              if [ "$gh_exit" -eq 1 ]; then
+                echo "Removing $dir (PR #$pr_number not found)"
+                rm -rf "$dir"
+                REMOVED=$((REMOVED + 1))
+                continue
+              else
+                echo "::error::gh pr view failed with exit code $gh_exit for PR #$pr_number"
+                exit 1
+              fi
             fi
 
             state=$(echo "$pr_data" | jq -r '.state //empty')

--- a/.github/workflows/cleanup-playwright-reports.yml
+++ b/.github/workflows/cleanup-playwright-reports.yml
@@ -45,8 +45,8 @@ jobs:
               continue
             fi
 
-            if ! pr_data=$(gh pr view "$pr_number" --json mergedAt,closedAt,state --repo "${{ github.repository }}" 2>/dev/null); then
-              gh_exit=$?
+            pr_data=$(gh pr view "$pr_number" --json mergedAt,closedAt,state --repo "${{ github.repository }}" 2>/dev/null) && gh_exit=$? || gh_exit=$?
+            if [ "$gh_exit" -ne 0 ]; then
               if [ "$gh_exit" -eq 1 ]; then
                 echo "Removing $dir (PR #$pr_number not found)"
                 rm -rf "$dir"

--- a/.github/workflows/cleanup-playwright-reports.yml
+++ b/.github/workflows/cleanup-playwright-reports.yml
@@ -1,0 +1,109 @@
+name: cleanup-playwright-reports
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+    inputs:
+      days:
+        description: 'Remove pr-* directories where the PR was merged/closed more than this many days ago'
+        required: false
+        default: '14'
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: gh-pages-write
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+
+      - name: Remove stale pr-* directories
+        id: cleanup
+        env:
+          DAYS: ${{ inputs.days || '14' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          REMOVED=0
+          cutoff_epoch=$(date -d "${DAYS} days ago" '+%s')
+
+          for dir in pr-*/; do
+            [ -d "$dir" ] || continue
+            dir="${dir%/}"
+            pr_number="${dir#pr-}"
+
+            if ! [[ "$pr_number" =~ ^[0-9]+$ ]]; then
+              echo "Removing $dir (not a valid PR number)"
+              rm -rf "$dir"
+              REMOVED=$((REMOVED + 1))
+              continue
+            fi
+
+            pr_data=$(gh pr view "$pr_number" --json mergedAt,closedAt,state --repo "${{ github.repository }}" 2>/dev/null || echo '{}')
+
+            if [ -z "$pr_data" ] || [ "$pr_data" = "{}" ]; then
+              echo "Removing $dir (PR #$pr_number not found)"
+              rm -rf "$dir"
+              REMOVED=$((REMOVED + 1))
+              continue
+            fi
+
+            state=$(echo "$pr_data" | jq -r '.state //empty')
+
+            if [ "$state" = "OPEN" ]; then
+              echo "Keeping $dir (PR #$pr_number is still open)"
+              continue
+            fi
+
+            merged_at=$(echo "$pr_data" | jq -r '.mergedAt //empty')
+            closed_at=$(echo "$pr_data" | jq -r '.closedAt //empty')
+
+            if [ -n "$merged_at" ]; then
+              relevant_date="$merged_at"
+              date_label="merged"
+            elif [ -n "$closed_at" ]; then
+              relevant_date="$closed_at"
+              date_label="closed"
+            else
+              echo "Keeping $dir (PR #$pr_number has no date info)"
+              continue
+            fi
+
+            relevant_epoch=$(date -d "$relevant_date" '+%s')
+
+            if [ "$relevant_epoch" -lt "$cutoff_epoch" ]; then
+              echo "Removing $dir (PR #$pr_number $date_label on ${relevant_date%%T*}, older than $DAYS days)"
+              rm -rf "$dir"
+              REMOVED=$((REMOVED + 1))
+            else
+              echo "Keeping $dir (PR #$pr_number $date_label on ${relevant_date%%T*}, within $DAYS days)"
+            fi
+          done
+
+          echo "removed=$REMOVED" >> "$GITHUB_OUTPUT"
+
+      - name: Create orphan commit and force push
+        if: steps.cleanup.outputs.removed != '0'
+        run: |
+          set -euo pipefail
+          REMOVED=${{ steps.cleanup.outputs.removed }}
+
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          git checkout --orphan cleanup
+          git add -A
+          git commit -m "Remove ${REMOVED} stale Playwright report(s) [skip ci]"
+
+          git push origin cleanup:gh-pages --force-with-lease

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,6 +105,9 @@ jobs:
     if: ${{ github.event_name == 'pull_request' }}
     needs: e2e
     runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-write
+      cancel-in-progress: false
     permissions:
       contents: write # push to gh-pages
       pull-requests: write # create/update PR comment

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
   workflow_call:
 
 permissions:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   lockfile-consistency:
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+    if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -16,7 +19,7 @@ permissions:
 
 jobs:
   lockfile-consistency:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
+    branches:
+      - main
   workflow_call:
   workflow_dispatch:
 


### PR DESCRIPTION
Two changes to GitHub Actions workflows:

## Scheduled cleanup for stale Playwright reports on gh-pages

Prevents unbounded storage growth on the gh-pages branch by automatically removing Playwright report directories for PRs that were merged/closed more than 14 days ago.

- cleanup-playwright-reports.yml — new workflow: weekly cron (Mondays 03:00 UTC) + manual workflow_dispatch
- e2e.yml — added gh-pages-write concurrency group to publish-report job

How it works:
- Queries the GitHub API (gh pr view) for each pr-* directory to determine merge/close date — no reliance on git log (which breaks after orphan commits rewrite history)
- Directories without a matching PR are also removed
- Open PRs are always kept
- Uses orphan commit + force-with-lease push to actually reclaim disk space (normal git rm leaves blobs in history)
- Shared gh-pages-write concurrency group serializes writes with the publish workflow
- Only targets pr-* directories; root-level files are preserved

## Add merge_group triggers to CI workflows

Required for GitHub merge queues — the following workflows now also trigger on merge_group events:
- lint.yml — merge_group trigger added; auto-commit step remains PR-only (correct for merge queue context)
- tests.yml — merge_group trigger added
- security.yml — merge_group trigger added; lockfile-consistency job condition updated to pull_request || merge_group