### PR TITLE
feat: add external users backfill command

### DIFF
--- a/.ai/skills/pr-description/SKILL.md
+++ b/.ai/skills/pr-description/SKILL.md
@@ -1,61 +1,70 @@
 ---
 name: pr-description
-description: "Use this skill when creating or editing pull request descriptions. Activate when the user asks to create a PR, write a PR description, or open a pull request. Covers: analyzing branch diffs, writing concise summaries, detecting multi-purpose PRs, linking issues, and structuring descriptions for reviewers. Do not use for commit messages, changelogs, or release notes."
+description: "Use this skill when making or editing pull request descriptions. Use for: branch diff review, clear PR summary, multi-purpose PR warning, reviewer setup commands, and PR creation. Not for commit messages, changelogs, or release notes."
 ---
 
-# Pull Request Descriptions
+# PR Description Skill
 
-## When to Use This Skill
+## When use this skill
 
-Activate when the user asks to create a pull request, write a PR description, or review/improve an existing PR description.
+Use when user asks:
 
-## Gathering Context
+- make PR
+- write PR text
+- improve PR text
 
-Before writing the description, collect information by running these commands:
+## First look (always)
+
+Run these first:
 
 ```bash
-# Understand what the branch changed vs the base branch
-git log --oneline main..HEAD
-git diff --stat main...HEAD
-git diff main...HEAD
-
-# Build GitHub file links for Details entries
+git status --short --branch
+git log --oneline origin/main..HEAD
+git diff --stat origin/main...HEAD
+git diff origin/main...HEAD
 git rev-parse --abbrev-ref HEAD
 gh repo view --json nameWithOwner -q .nameWithOwner
 ```
 
-Use `main` or the appropriate base branch. Adjust if the user specifies a different target.
+If base branch not `main`, swap base:
 
-## Core Principles
+- use `origin/<base>..HEAD` for commit list
+- use `origin/<base>...HEAD` for diff
 
-1. **Short over long.** A description that gets fully read beats a thorough one that gets skimmed. Aim for a few focused sentences, not paragraphs.
-2. **No code in the description.** Reviewers use the diff viewer for code. The description answers _why_ and _what_, not _how_.
-3. **Lead with impact.** Start with what improved for users or the system (e.g. safer, faster, less manual work, better UX, fewer failure modes), then add context.
-4. **Assume reviewers run locally.** If setup steps are needed after pulling the branch, call them out explicitly.
-5. **Ask when unclear.** If the commits are ambiguous or the purpose is unclear, ask the user before guessing.
+## Core rules
 
-## Structure
+1. Short beat long.
+2. No code dump in PR text.
+3. Start with impact (why this matters).
+4. Reviewer setup must be diff-based, not habit-based.
+5. If branch has mixed unrelated work, warn user first.
 
-Use this template as a starting point, but **drop any section that has nothing meaningful to say**. An empty section is worse than no section.
+## Body shape
+
+Use this shape. Drop empty sections.
 
 ````markdown
-<1-3 sentences: what improved and why this matters>
+<1-3 lines: what got better and why>
 
 ## Details
 
-- [ImportantFile.php](https://github.com/<owner>/<repo>/blob/<branch>/path/to/ImportantFile.php) - <only if this file needs special reviewer attention>
+- [ImportantFile.php](https://github.com/<owner>/<repo>/blob/<branch>/path/to/ImportantFile.php) - why reviewer should look
 
 ## Notes
 
-<only if relevant: deployment steps, breaking changes, migration instructions, new env vars, risk callout, testing notes, or screenshot placeholder -- whatever genuinely helps the reviewer>
+<only real must-know: deploy steps, risk, migration/backfill instructions, env/config change, test note>
 
 ## Reviewer Setup
 
-In this PR vs `origin/main`, changes were made in <area(s)>. You likely need to run:
+In this PR vs `origin/main`, changes were made in <correct areas from diff>. You likely need to run:
 
 ```sh
-composer update
+composer install
+npm install
 npm run build
+php artisan migrate
+php artisan boost:update
+php artisan optimize:clear
 ```
 
 Fixes #<number>
@@ -65,91 +74,107 @@ Fixes #<number>
 _<author>_
 ````
 
-### Section Guidelines
+## Reviewer Setup rules (strict)
 
-- **Opening paragraph (no heading): Always present.** Do not start with `## Summary`. In 1-3 sentences, state outcomes and impact, not implementation trivia. Prefer phrasing like:
-    - Removed manual review work from critical flow.
-    - Made validation always enforce server-side instead of relying on user behavior.
-    - Added a clean user exit path to prevent orphaned test data.
-      Avoid vague or circular wording that just repeats filenames/action names.
-- **Reviewer Setup**: Include only the commands that apply based on the diff:
-    - Put this section at the very end of the PR body (after `Details` / `Notes`, before issue-closing lines if present).
-    - Use a short sentence explaining what changed and why commands are needed, then a fenced `sh` block with commands.
-    - If `composer.json` or `composer.lock` changed, include `composer update`.
-    - If migrations changed, include `php artisan migrate`.
-    - If frontend sources/build inputs changed (Blade/JS/CSS/Vite assets), include `npm run build`.
-    - Include other setup commands when relevant (not limited to the three above).
-      Skip this section entirely if no reviewer setup commands are needed.
-- **Details**: Optional. Replace `Key Files` with `Details` when useful. Include only genuinely important callouts. If listing files:
-    - Use filename-only link labels (e.g. `[InspectWeblingInvoicePdfAction.php](...)`), not full-path labels.
-    - Link each file to its GitHub blob URL on the current PR branch, e.g. `https://github.com/<owner>/<repo>/blob/<branch>/<path>`.
-    - Include the list only when it helps reviewer focus; omit if obvious or redundant.
-- **Notes**: Optional catch-all. Only include when there is something a reviewer or deployer _needs to know_. Examples:
-    - Breaking changes that affect other teams or downstream consumers.
-    - Migrations, new env vars, or config changes that require deployment action.
-    - A brief testing note if coverage is unusual (e.g. "no tests -- pure CSS change" or "added integration tests for the new flow").
-    - A risk callout if the change touches auth, payments, or data integrity.
-    - A screenshot placeholder (`> TODO: attach before/after screenshots`) for visual changes.
-    - Do **not** include these subsections by default. Only when they are genuinely important.
-- **Fixes #N**: Only include when the PR actually fixes/closes a GitHub issue. Use `Fixes #<number>` syntax (one per line if multiple). Do not fabricate issue numbers -- ask the user if unsure.
-- **Ending line + quote (required):** End every PR description with horizontal rule, then one inspiring quote line. Format:
+### A) Must include
 
-  ```markdown
-  ---
-  **«<inspiring quote here>»**
-  _<author>_
-  ```
+- `php artisan boost:update` (always)
+- `php artisan optimize:clear` (always, and always last)
 
-  Use `php artisan inspire --no-interaction` to source quote.
+### B) Include when diff says yes
 
-## Multi-Purpose PR Detection
+- if `composer.json` or `composer.lock` changed -> `composer install`
+- if `package.json` or JS lockfile changed (`package-lock.json`, `pnpm-lock.yaml`, `yarn.lock`, `bun.lockb`) -> `npm install`
+- if frontend inputs changed (Blade, JS, CSS, Tailwind, Vite inputs) -> `npm run build`
+- if migrations changed -> `php artisan migrate`
 
-Analyze the commits on the branch. If they contain clearly unrelated changes (e.g. a bug fix plus an unrelated feature), **warn the user** before writing the description:
+### C) Command order
 
-> It looks like this branch contains unrelated changes:
+Use this order only when command exists:
+
+1. dependency install (`composer install`, `npm install`)
+2. build/migrate (`npm run build`, `php artisan migrate`)
+3. `php artisan boost:update`
+4. `php artisan optimize:clear` (last)
+
+### D) Wording
+
+Keep this exact style:
+
+- heading: `## Reviewer Setup`
+- intro line: `In this PR vs \`origin/main\`, changes were made in ... You likely need to run:`
+- fenced `sh` block with only needed commands
+
+## Details section rules
+
+- Optional section.
+- Only list files that need reviewer focus.
+- Use filename-only link text.
+- Link to blob on current branch.
+
+## Notes section rules
+
+Only add when truly needed:
+
+- deploy step
+- backfill/data migration step
+- breaking/risky behavior
+- env/config requirement
+- unusual test coverage note
+
+## Multi-purpose PR check
+
+If commits look unrelated, warn user first:
+
+> Branch look mixed:
 >
-> - Commits A, B: fix payment rounding bug
-> - Commits C, D: add user avatar upload
+> - commits A/B: one topic
+> - commits C/D: another topic
 >
-> Would you like to split this into separate PRs, or should I write a combined description?
+> Split PR, or keep combined?
 
-If the user wants a combined description, organize the summary to clearly separate the concerns.
+If user keeps combined, separate concerns clearly in summary.
 
-## Creating the PR
+## Make PR command
 
-Always create PRs as **drafts** unless the user explicitly asks for a ready PR. Use the `--draft` flag:
+Default: draft PR unless user says ready.
 
 ```bash
-gh pr create --draft --title "Short, descriptive title" --body "$(cat <<'EOF'
-<1-3 sentences: what improved and why this matters>
-
-## Details
-
-- [ImportantFile.php](https://github.com/<owner>/<repo>/blob/<branch>/path/to/ImportantFile.php) - why reviewers should look here
+gh pr create --draft --title "short title" --body "$(cat <<'EOF'
+<impact summary>
 
 ## Reviewer Setup
 
-In this PR vs `origin/main`, changes were made in dependencies and frontend assets. You likely need to run:
+In this PR vs `origin/main`, changes were made in <areas>. You likely need to run:
 
 ~~~sh
-composer update
-npm run build
+composer install
+php artisan boost:update
+php artisan optimize:clear
 ~~~
 
-Fixes #123
+---
+**«<quote>»**
+_<author>_
 EOF
 )"
-
 ```
 
-## Common Mistakes to Avoid
+## Quote rule
 
-- Writing a commit-by-commit changelog instead of a summary.
-- Opening with a `## Summary` heading.
-- Including code snippets or diffs in the description.
-- Adding boilerplate sections that say nothing ("No breaking changes", "N/A").
-- Listing files that only restate the obvious behavior from their names.
-- Listing files without links to the branch blob URL.
-- Formatting setup commands as plain text bullets instead of a fenced `sh` block.
-- Guessing issue numbers instead of asking.
-- Writing a long description for a small, obvious change.
+End PR body with quote block. Fetch quote with:
+
+```bash
+php artisan inspire --no-interaction
+```
+
+## Common mistakes
+
+- writing commit-by-commit changelog
+- opening with `## Summary`
+- putting code snippets in PR body
+- guessing issue numbers
+- adding empty sections
+- adding setup commands not implied by diff
+- using `composer update` in reviewer setup
+- putting `php artisan optimize:clear` anywhere but last

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,7 +42,7 @@ This project has domain-specific skills available. You MUST activate the relevan
 
 - `dependency-upgrade` — Upgrade dependencies with a risk-based workflow. batch minor updates and handle major updates with migration guides, incremental checks, and fast failure detection.
 - `pr-description` — Use this skill when creating or editing pull request descriptions. Activate when the user asks to create a PR, write a PR description, or open a pull request. Covers: analyzing branch diffs, writing concise summaries, detecting multi-purpose PRs, linking issues, and structuring descriptions for reviewers. Do not use for commit messages, changelogs, or release notes.
-- `precommit-testing` — Run and interpret the AI-first precommit quality gate for this project, including when to run each sub-command and when to avoid rerunning the full suite.
+- `precommit-testing` — Run tests and linting before every commit.
 
 ## Conventions
 
@@ -126,6 +126,13 @@ This project has domain-specific skills available. You MUST activate the relevan
 # Deployment
 
 - Laravel can be deployed using [Laravel Cloud](https://cloud.laravel.com/), which is the fastest way to deploy and scale production Laravel applications.
+
+=== herd rules ===
+
+# Laravel Herd
+
+- The application is served by Laravel Herd at `https?://[kebab-case-project-dir].test`. Use the `get-absolute-url` tool to generate valid URLs. Never run commands to serve the site. It is always available.
+- Use the `herd` CLI to manage services, PHP versions, and sites (e.g. `herd sites`, `herd services:start <service>`, `herd php:list`). Run `herd list` to discover all available commands.
 
 === tests rules ===
 

--- a/app/Components/LoginForm.php
+++ b/app/Components/LoginForm.php
@@ -36,6 +36,8 @@ class LoginForm extends Component
     {
         $this->protectAgainstSpam();
 
+        $this->email = trim(mb_strtolower((string) $this->email));
+
         try {
             $this->validate();
         } catch (ValidationException $validationException) {
@@ -54,22 +56,24 @@ class LoginForm extends Component
         }
 
         try {
+            $normalizedEmail = (string) $this->email;
+
+            $externalUser = ExternalUser::query()->whereRaw('LOWER(TRIM(email)) = ?', [$normalizedEmail])->first();
 
             // get all login tokens
-            $athlete = Athlete::query()->where('email', $this->email)->first();
+            $athlete = Athlete::query()->whereRaw('LOWER(TRIM(email)) = ?', [$normalizedEmail])->first();
             $athleteLoginToken = $athlete ? $athlete->login_token : '';
 
-            $donor = Donor::query()->where('email', $this->email)->first();
+            $donor = Donor::query()->whereRaw('LOWER(TRIM(email)) = ?', [$normalizedEmail])->first();
             $donorLoginToken = $donor ? $donor->login_token : '';
 
-            $user = User::query()->where('email', $this->email)->first();
+            $user = User::query()->whereRaw('LOWER(TRIM(email)) = ?', [$normalizedEmail])->first();
             $userLoginUrl = '';
             if ($user) {
                 $userUuid = $user->uuid;
                 $userLoginUrl = URL::temporarySignedRoute('login-uuid', now()->addMinutes(15), ['uuid' => $userUuid]);
             }
 
-            $externalUser = ExternalUser::query()->where('email', $this->email)->first();
             $externalUserLoginUrl = '';
             if ($externalUser) {
                 $externalUserUuid = $externalUser->uuid;
@@ -77,14 +81,14 @@ class LoginForm extends Component
             }
 
             // get the first name
-            if ($athlete) {
+            if ($externalUser) {
+                $first_name = $externalUser->first_name;
+            } elseif ($athlete) {
                 $first_name = $athlete->first_name;
             } elseif ($donor) {
                 $first_name = $donor->first_name;
             } elseif ($user) {
                 $first_name = $user->name;
-            } elseif ($externalUser) {
-                $first_name = $externalUser->first_name;
             } else {
                 $first_name = '';
             }
@@ -104,7 +108,7 @@ class LoginForm extends Component
                     external_user_login_url: $externalUserLoginUrl,
                 );
 
-                Notification::route('mail', $this->email)->notify($notification);
+                Notification::route('mail', $normalizedEmail)->notify($notification);
             }
 
         } catch (Exception $exception) {

--- a/app/Components/LoginForm.php
+++ b/app/Components/LoginForm.php
@@ -56,7 +56,7 @@ class LoginForm extends Component
         }
 
         try {
-            $normalizedEmail = (string) $this->email;
+            $normalizedEmail = $this->email;
 
             $externalUser = ExternalUser::query()->whereRaw('LOWER(TRIM(email)) = ?', [$normalizedEmail])->first();
 

--- a/app/Console/Commands/BackfillExternalUsersCommand.php
+++ b/app/Console/Commands/BackfillExternalUsersCommand.php
@@ -1,0 +1,511 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Athlete;
+use App\Models\AthleteRegistration;
+use App\Models\Donation;
+use App\Models\Donor;
+use App\Models\ExternalUser;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+class BackfillExternalUsersCommand extends Command
+{
+    protected $signature = 'hfm:backfill:external-users
+        {--dry-run : Show preflight results without writing}';
+
+    protected $description = 'Backfill external users with strict preflight safety checks';
+
+    private const TARGET_SCHEMA_NOT_EMPTY_MESSAGE = 'Target tables/columns are not empty.';
+
+    public function handle(): int
+    {
+        $isDryRun = (bool) $this->option('dry-run');
+
+        $this->components->info('External users backfill preflight');
+
+        $preflight = $this->runPreflightChecks();
+
+        foreach ($preflight['details'] as $label => $count) {
+            $this->line($label.': '.$count);
+        }
+
+        if ($preflight['blockers'] !== []) {
+            $this->newLine();
+            $this->components->error('Preflight failed. Fix blockers before running write mode.');
+
+            foreach ($preflight['blockers'] as $blocker) {
+                $this->line('- '.$blocker);
+            }
+
+            return self::FAILURE;
+        }
+
+        $this->newLine();
+        $this->components->info('Preflight passed. Safe to write.');
+
+        $plan = $this->buildPlan();
+
+        $this->newLine();
+        $this->line('identity rows to create: '.$plan['external_user_rows']->count());
+        $this->line('athlete registrations to create: '.$plan['athlete_registration_rows']->count());
+        $this->line('donations to update: '.$plan['donation_updates']->count());
+
+        if ($isDryRun) {
+            $this->line('Dry run: write phase not executed.');
+            $this->printDryRunMergePreview($plan['merge_preview']);
+
+            return self::SUCCESS;
+        }
+
+        DB::transaction(function () use ($plan): void {
+            $this->executeWritePlan($plan);
+            $this->validatePostWriteParity();
+        });
+
+        $this->components->info('Backfill write completed successfully.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array{details: array<string, int>, blockers: array<int, string>}
+     */
+    protected function runPreflightChecks(): array
+    {
+        $details = $this->collectPreflightDetails();
+        $blockers = $this->collectPreflightBlockers($details);
+
+        return [
+            'details' => $details,
+            'blockers' => $blockers,
+        ];
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    protected function collectPreflightDetails(): array
+    {
+        return [
+            'duplicate normalized donor emails' => $this->countDuplicateNormalizedDonorEmails(),
+            'duplicate normalized athlete emails' => $this->countDuplicateNormalizedAthleteEmails(),
+            'donors with null email' => (int) DB::table('donors')->whereNull('email')->count(),
+            'athletes with null email' => (int) DB::table('athletes')->whereNull('email')->count(),
+            'donors with blank normalized email' => $this->countDonorsWithBlankNormalizedEmail(),
+            'athletes with blank normalized email' => $this->countAthletesWithBlankNormalizedEmail(),
+            'duplicate donor/athlete donation pairs' => $this->countDuplicateDonationPairs(),
+            'athletes without donation_event_id' => (int) DB::table('athletes')->whereNull('donation_event_id')->count(),
+            'donations with missing donor relation' => $this->countDonationsMissingDonor(),
+            'donations with missing athlete relation' => $this->countDonationsMissingAthlete(),
+            'external_users rows' => (int) DB::table('external_users')->count(),
+            'athlete_registrations rows' => (int) DB::table('athlete_registrations')->count(),
+            'donations with donor_external_user_id' => (int) DB::table('donations')->whereNotNull('donor_external_user_id')->count(),
+            'donations with athlete_registration_id' => (int) DB::table('donations')->whereNotNull('athlete_registration_id')->count(),
+        ];
+    }
+
+    /**
+     * @param  array<string, int>  $details
+     * @return array<int, string>
+     */
+    protected function collectPreflightBlockers(array $details): array
+    {
+        $blockers = [];
+
+        if ($details['duplicate normalized donor emails'] > 0) {
+            $blockers[] = 'Duplicate normalized donor emails found.';
+        }
+
+        if ($details['duplicate normalized athlete emails'] > 0) {
+            $blockers[] = 'Duplicate normalized athlete emails found.';
+        }
+
+        if ($details['donors with null email'] > 0) {
+            $blockers[] = 'Donors with null emails found.';
+        }
+
+        if ($details['athletes with null email'] > 0) {
+            $blockers[] = 'Athletes with null emails found.';
+        }
+
+        if ($details['donors with blank normalized email'] > 0) {
+            $blockers[] = 'Donors with blank normalized emails found.';
+        }
+
+        if ($details['athletes with blank normalized email'] > 0) {
+            $blockers[] = 'Athletes with blank normalized emails found.';
+        }
+
+        if ($details['duplicate donor/athlete donation pairs'] > 0) {
+            $blockers[] = 'Duplicate legacy donation pairs (donor_id, athlete_id) found.';
+        }
+
+        if ($details['athletes without donation_event_id'] > 0) {
+            $blockers[] = 'Athletes without donation_event_id found.';
+        }
+
+        if ($details['donations with missing donor relation'] > 0 || $details['donations with missing athlete relation'] > 0) {
+            $blockers[] = 'Donations with missing legacy donor or athlete relations found.';
+        }
+
+        if ($this->targetSchemaContainsData($details)) {
+            $blockers[] = self::TARGET_SCHEMA_NOT_EMPTY_MESSAGE;
+        }
+
+        return $blockers;
+    }
+
+    /**
+     * @param  array<string, int>  $details
+     */
+    protected function targetSchemaContainsData(array $details): bool
+    {
+        return $details['external_users rows'] > 0
+            || $details['athlete_registrations rows'] > 0
+            || $details['donations with donor_external_user_id'] > 0
+            || $details['donations with athlete_registration_id'] > 0;
+    }
+
+    protected function countDuplicateNormalizedDonorEmails(): int
+    {
+        $normalizedCounts = DB::table('donors')
+            ->whereNotNull('email')
+            ->pluck('email')
+            ->map(function (mixed $email): string {
+                if (! is_string($email)) {
+                    return '';
+                }
+
+                return trim(mb_strtolower($email));
+            })
+            ->filter(fn (string $email): bool => $email !== '')
+            ->countBy();
+
+        return $normalizedCounts->filter(fn (int $count): bool => $count > 1)->count();
+    }
+
+    protected function countDuplicateNormalizedAthleteEmails(): int
+    {
+        $normalizedCounts = DB::table('athletes')
+            ->whereNotNull('email')
+            ->pluck('email')
+            ->map(function (mixed $email): string {
+                if (! is_string($email)) {
+                    return '';
+                }
+
+                return trim(mb_strtolower($email));
+            })
+            ->filter(fn (string $email): bool => $email !== '')
+            ->countBy();
+
+        return $normalizedCounts->filter(fn (int $count): bool => $count > 1)->count();
+    }
+
+    protected function countDuplicateDonationPairs(): int
+    {
+        return (int) DB::table('donations')
+            ->select('donor_id', 'athlete_id')
+            ->groupBy('donor_id', 'athlete_id')
+            ->havingRaw('count(*) > 1')
+            ->count();
+    }
+
+    protected function countDonorsWithBlankNormalizedEmail(): int
+    {
+        return (int) DB::table('donors')
+            ->whereRaw('TRIM(email) = ?', [''])
+            ->count();
+    }
+
+    protected function countAthletesWithBlankNormalizedEmail(): int
+    {
+        return (int) DB::table('athletes')
+            ->whereRaw('TRIM(email) = ?', [''])
+            ->count();
+    }
+
+    protected function countDonationsMissingDonor(): int
+    {
+        return (int) DB::table('donations')
+            ->leftJoin('donors', 'donations.donor_id', '=', 'donors.id')
+            ->whereNull('donors.id')
+            ->count();
+    }
+
+    protected function countDonationsMissingAthlete(): int
+    {
+        return (int) DB::table('donations')
+            ->leftJoin('athletes', 'donations.athlete_id', '=', 'athletes.id')
+            ->whereNull('athletes.id')
+            ->count();
+    }
+
+    /**
+     * @param  array{
+     *     external_user_rows: Collection<int, array<string, mixed>>,
+     *     athlete_registration_rows: Collection<int, array<string, mixed>>,
+     *     donation_updates: Collection<int, array{donation_id: int, donor_id: int, athlete_id: int}>,
+     *     merge_preview: Collection<int, string>
+     * }  $plan
+     */
+    protected function executeWritePlan(array $plan): void
+    {
+        ExternalUser::query()->insert($plan['external_user_rows']->all());
+
+        $externalUsersByLegacyAthleteId = ExternalUser::query()
+            ->whereNotNull('legacy_athlete_id')
+            ->pluck('id', 'legacy_athlete_id');
+
+        AthleteRegistration::query()->insert(
+            $plan['athlete_registration_rows']->map(function (array $row) use ($externalUsersByLegacyAthleteId): array {
+                $row['external_user_id'] = $externalUsersByLegacyAthleteId[(int) $row['legacy_athlete_id']];
+                unset($row['legacy_athlete_id']);
+
+                return $row;
+            })->all()
+        );
+
+        $externalUsersByLegacyDonorId = ExternalUser::query()
+            ->whereNotNull('legacy_donor_id')
+            ->pluck('id', 'legacy_donor_id');
+
+        $athleteRegistrationsByAthleteId = AthleteRegistration::query()
+            ->join('external_users', 'external_users.id', '=', 'athlete_registrations.external_user_id')
+            ->pluck('athlete_registrations.id', 'external_users.legacy_athlete_id');
+
+        foreach ($plan['donation_updates'] as $update) {
+            Donation::query()
+                ->whereKey((int) $update['donation_id'])
+                ->update([
+                    'donor_external_user_id' => $externalUsersByLegacyDonorId[(int) $update['donor_id']],
+                    'athlete_registration_id' => $athleteRegistrationsByAthleteId[(int) $update['athlete_id']],
+                ]);
+        }
+    }
+
+    /**
+     * @return array{
+     *     external_user_rows: Collection<int, array<string, mixed>>,
+     *     athlete_registration_rows: Collection<int, array<string, mixed>>,
+     *     donation_updates: Collection<int, array{donation_id: int, donor_id: int, athlete_id: int}>,
+     *     merge_preview: Collection<int, string>
+     * }
+     */
+    protected function buildPlan(): array
+    {
+        $now = now();
+        $reservedPublicIds = DB::table('external_users')->pluck('public_id')->filter()->values()->all();
+
+        $athletes = Athlete::query()->orderBy('id')->get();
+        $donors = Donor::query()->orderBy('id')->get();
+        $donations = Donation::query()->orderBy('id')->get();
+
+        /** @var Collection<string, array{athlete: Athlete|null, donor: Donor|null}> $identityMap */
+        $identityMap = collect();
+
+        foreach ($athletes as $athlete) {
+            $normalizedEmail = $this->normalizeEmail($athlete->email);
+            $existing = $identityMap->get($normalizedEmail, ['athlete' => null, 'donor' => null]);
+            $existing['athlete'] = $athlete;
+            $identityMap->put($normalizedEmail, $existing);
+        }
+
+        foreach ($donors as $donor) {
+            $normalizedEmail = $this->normalizeEmail($donor->email);
+            $existing = $identityMap->get($normalizedEmail, ['athlete' => null, 'donor' => null]);
+            $existing['donor'] = $donor;
+            $identityMap->put($normalizedEmail, $existing);
+        }
+
+        $externalUserRows = collect();
+        $mergePreview = collect();
+
+        foreach ($identityMap as $email => $identity) {
+            $athlete = $identity['athlete'];
+            $donor = $identity['donor'];
+
+            $externalUserRows->push([
+                'uuid' => (string) str()->uuid(),
+                'public_id' => $this->generatePublicId($reservedPublicIds),
+                'first_name' => $this->chooseField($athlete?->first_name, $donor?->first_name),
+                'last_name' => $this->chooseField($athlete?->last_name, $donor?->last_name),
+                'address' => $this->chooseField($athlete?->address, $donor?->address),
+                'zip_code' => $this->chooseField($athlete?->zip_code !== null ? (string) $athlete->zip_code : null, $donor?->zip_code),
+                'city' => $this->chooseField($athlete?->city, $donor?->city),
+                'country_of_residence' => $this->resolveCountryOfResidence($donor?->country_of_residence),
+                'phone_number' => $this->chooseField($athlete?->phone_number, $donor?->phone_number),
+                'email' => $email,
+                'legacy_athlete_id' => $athlete?->id,
+                'legacy_donor_id' => $donor?->id,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+            $mergePreview->push(sprintf(
+                '%s => athlete:%s donor:%s',
+                $email,
+                $athlete?->id !== null ? (string) $athlete->id : '-',
+                $donor?->id !== null ? (string) $donor->id : '-'
+            ));
+        }
+
+        $athleteRegistrationRows = $athletes->map(function (Athlete $athlete) use ($now): array {
+            return [
+                'legacy_athlete_id' => $athlete->id,
+                'donation_event_id' => $athlete->donation_event_id,
+                'sport_type_id' => $athlete->sport_type_id,
+                'partner_id' => $athlete->partner_id,
+                'rounds_estimated' => $athlete->rounds_estimated,
+                'rounds_done' => $athlete->rounds_done,
+                'comment' => $athlete->comment,
+                'verified' => $athlete->verified,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        });
+
+        $donationUpdates = $donations->map(function (Donation $donation): array {
+            return [
+                'donation_id' => $donation->id,
+                'donor_id' => (int) $donation->donor_id,
+                'athlete_id' => (int) $donation->athlete_id,
+            ];
+        });
+
+        return [
+            'external_user_rows' => $externalUserRows,
+            'athlete_registration_rows' => $athleteRegistrationRows,
+            'donation_updates' => $donationUpdates,
+            'merge_preview' => $mergePreview,
+        ];
+    }
+
+    protected function normalizeEmail(?string $email): string
+    {
+        return trim(mb_strtolower((string) $email));
+    }
+
+    /**
+     * @param  array<int, string>  $reservedPublicIds
+     */
+    protected function generatePublicId(array &$reservedPublicIds): string
+    {
+        $charset = 'ABCDEFGHJKMNPQRSTUVWXYZ23456789';
+
+        do {
+            $id = '';
+
+            for ($index = 0; $index < 6; $index++) {
+                $id .= $charset[random_int(0, strlen($charset) - 1)];
+            }
+        } while (in_array($id, $reservedPublicIds, true));
+
+        $reservedPublicIds[] = $id;
+
+        return $id;
+    }
+
+    protected function chooseField(mixed $athleteValue, mixed $donorValue): ?string
+    {
+        $athleteString = is_string($athleteValue) ? trim($athleteValue) : '';
+        if ($athleteString !== '') {
+            return $athleteString;
+        }
+
+        $donorString = is_string($donorValue) ? trim($donorValue) : '';
+        if ($donorString !== '') {
+            return $donorString;
+        }
+
+        return null;
+    }
+
+    protected function resolveCountryOfResidence(?string $countryOfResidence): string
+    {
+        $normalizedCountry = trim((string) $countryOfResidence);
+
+        if ($normalizedCountry === '') {
+            return 'CH';
+        }
+
+        return $normalizedCountry;
+    }
+
+    protected function printDryRunMergePreview(Collection $mergePreview): void
+    {
+        $this->newLine();
+        $this->line('Dry-run merge preview:');
+
+        foreach ($mergePreview->take(25) as $line) {
+            $this->line('- '.$line);
+        }
+
+        if ($mergePreview->count() > 25) {
+            $this->line('- ... and '.($mergePreview->count() - 25).' more');
+        }
+    }
+
+    protected function validatePostWriteParity(): void
+    {
+        $legacyAthleteCount = (int) Athlete::query()->count();
+        $newAthleteRegistrationCount = (int) AthleteRegistration::query()->count();
+
+        if ($legacyAthleteCount !== $newAthleteRegistrationCount) {
+            $this->fail('Parity check failed: athlete registrations count mismatch.');
+        }
+
+        $legacyDonationCount = (int) Donation::query()->count();
+        $newDonationMappedCount = (int) Donation::query()
+            ->whereNotNull('donor_external_user_id')
+            ->whereNotNull('athlete_registration_id')
+            ->count();
+
+        if ($legacyDonationCount !== $newDonationMappedCount) {
+            $this->fail('Parity check failed: donations mapping count mismatch.');
+        }
+
+        $legacyAthleteMappedCount = (int) ExternalUser::query()->whereNotNull('legacy_athlete_id')->count();
+        if ($legacyAthleteMappedCount !== $legacyAthleteCount) {
+            $this->fail('Parity check failed: legacy athlete mapping mismatch.');
+        }
+
+        $legacyDonorCount = (int) Donor::query()->count();
+        $legacyDonorMappedCount = (int) ExternalUser::query()->whereNotNull('legacy_donor_id')->count();
+        if ($legacyDonorMappedCount !== $legacyDonorCount) {
+            $this->fail('Parity check failed: legacy donor mapping mismatch.');
+        }
+
+        $legacyRows = DB::table('donations')
+            ->join('athletes', 'athletes.id', '=', 'donations.athlete_id')
+            ->selectRaw('athletes.donation_event_id as event_id, donations.donor_id as donor_id, SUM(donations.amount_per_round) as total')
+            ->groupBy('athletes.donation_event_id', 'donations.donor_id')
+            ->get()
+            ->mapWithKeys(fn (object $row): array => [sprintf('%d|%d', (int) $row->event_id, (int) $row->donor_id) => (float) $row->total]);
+
+        $newRows = DB::table('donations')
+            ->join('athlete_registrations', 'athlete_registrations.id', '=', 'donations.athlete_registration_id')
+            ->join('external_users', 'external_users.id', '=', 'donations.donor_external_user_id')
+            ->selectRaw('athlete_registrations.donation_event_id as event_id, external_users.legacy_donor_id as donor_id, SUM(donations.amount_per_round) as total')
+            ->groupBy('athlete_registrations.donation_event_id', 'external_users.legacy_donor_id')
+            ->get()
+            ->mapWithKeys(fn (object $row): array => [sprintf('%d|%d', (int) $row->event_id, (int) $row->donor_id) => (float) $row->total]);
+
+        if ($legacyRows->count() !== $newRows->count()) {
+            $this->fail('Parity check failed: grouped donation totals row count mismatch.');
+        }
+
+        foreach ($legacyRows as $key => $legacyTotal) {
+            $newTotal = $newRows->get($key);
+
+            if ($newTotal === null || abs($legacyTotal - $newTotal) > 0.00001) {
+                $this->fail('Parity check failed: grouped donation totals mismatch for '.$key.'.');
+            }
+        }
+    }
+}

--- a/app/Console/Commands/BackfillExternalUsersCommand.php
+++ b/app/Console/Commands/BackfillExternalUsersCommand.php
@@ -247,12 +247,7 @@ class BackfillExternalUsersCommand extends Command
     }
 
     /**
-     * @param  array{
-     *     external_user_rows: Collection<int, array<string, mixed>>,
-     *     athlete_registration_rows: Collection<int, array<string, mixed>>,
-     *     donation_updates: Collection<int, array{donation_id: int, donor_id: int, athlete_id: int}>,
-     *     merge_preview: Collection<int, string>
-     * }  $plan
+     * @param  array<string, Collection<int, mixed>>  $plan
      */
     protected function executeWritePlan(array $plan): void
     {
@@ -290,12 +285,7 @@ class BackfillExternalUsersCommand extends Command
     }
 
     /**
-     * @return array{
-     *     external_user_rows: Collection<int, array<string, mixed>>,
-     *     athlete_registration_rows: Collection<int, array<string, mixed>>,
-     *     donation_updates: Collection<int, array{donation_id: int, donor_id: int, athlete_id: int}>,
-     *     merge_preview: Collection<int, string>
-     * }
+     * @return array<string, Collection<int, mixed>>
      */
     protected function buildPlan(): array
     {
@@ -323,7 +313,9 @@ class BackfillExternalUsersCommand extends Command
             $identityMap->put($normalizedEmail, $existing);
         }
 
+        /** @var Collection<int, array<string, mixed>> $externalUserRows */
         $externalUserRows = collect();
+        /** @var Collection<int, string> $mergePreview */
         $mergePreview = collect();
 
         foreach ($identityMap as $email => $identity) {

--- a/app/Http/Controllers/PortalController.php
+++ b/app/Http/Controllers/PortalController.php
@@ -7,7 +7,6 @@ namespace App\Http\Controllers;
 use App\Models\ExternalUser;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Collection;
 
 class PortalController extends Controller
 {
@@ -43,11 +42,11 @@ class PortalController extends Controller
     }
 
     /**
-     * @param  Collection<int, Collection<int, mixed>>  $athleteRegistrationsByEvent
-     * @param  Collection<int, Collection<int, mixed>>  $donationsAsDonorByEvent
+     * @param  iterable<int|string, mixed>  $athleteRegistrationsByEvent
+     * @param  iterable<int|string, mixed>  $donationsAsDonorByEvent
      * @return array<int, string>
      */
-    private function eventTitleMap(Collection $athleteRegistrationsByEvent, Collection $donationsAsDonorByEvent): array
+    protected function eventTitleMap(iterable $athleteRegistrationsByEvent, iterable $donationsAsDonorByEvent): array
     {
         $titles = [];
 

--- a/app/Http/Controllers/PortalController.php
+++ b/app/Http/Controllers/PortalController.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Models\ExternalUser;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+
+class PortalController extends Controller
+{
+    public function __invoke(): Factory|View
+    {
+        /** @var ExternalUser $externalUser */
+        $externalUser = auth('external')->user();
+
+        $externalUser->load([
+            'athleteRegistrations.donationEvent',
+            'athleteRegistrations.sportType',
+            'athleteRegistrations.donations.donorExternalUser',
+            'donationsAsDonor.athleteRegistration.externalUser',
+            'donationsAsDonor.athleteRegistration.donationEvent',
+        ]);
+
+        $athleteRegistrationsByEvent = $externalUser->athleteRegistrations
+            ->sortBy('donationEvent.starts_at')
+            ->groupBy('donation_event_id');
+
+        $donationsAsDonorByEvent = $externalUser->donationsAsDonor
+            ->sortBy('athleteRegistration.donationEvent.starts_at')
+            ->groupBy(fn ($donation): int => (int) $donation->athleteRegistration?->donation_event_id);
+
+        $eventTitles = $this->eventTitleMap($athleteRegistrationsByEvent, $donationsAsDonorByEvent);
+
+        return view('pages.portal', [
+            'externalUser' => $externalUser,
+            'athleteRegistrationsByEvent' => $athleteRegistrationsByEvent,
+            'donationsAsDonorByEvent' => $donationsAsDonorByEvent,
+            'eventTitles' => $eventTitles,
+        ]);
+    }
+
+    /**
+     * @param  Collection<int, Collection<int, mixed>>  $athleteRegistrationsByEvent
+     * @param  Collection<int, Collection<int, mixed>>  $donationsAsDonorByEvent
+     * @return array<int, string>
+     */
+    private function eventTitleMap(Collection $athleteRegistrationsByEvent, Collection $donationsAsDonorByEvent): array
+    {
+        $titles = [];
+
+        foreach ($athleteRegistrationsByEvent as $eventId => $registrations) {
+            $title = $registrations->first()?->donationEvent?->title;
+
+            if (is_string($title) && $title !== '') {
+                $titles[(int) $eventId] = $title;
+            }
+        }
+
+        foreach ($donationsAsDonorByEvent as $eventId => $donations) {
+            $title = $donations->first()?->athleteRegistration?->donationEvent?->title;
+
+            if (is_string($title) && $title !== '') {
+                $titles[(int) $eventId] = $title;
+            }
+        }
+
+        return $titles;
+    }
+}

--- a/app/Support/Datatable/Actions/DonorRowActionFactory.php
+++ b/app/Support/Datatable/Actions/DonorRowActionFactory.php
@@ -33,17 +33,6 @@ class DonorRowActionFactory
 
         $actions = [
             new DatatableActionDefinition(
-                key: 'donor-login',
-                group: 'Spender:in',
-                label: 'Als Spender einloggen',
-                execute: static fn (array $payload): array => [
-                    'type' => 'href',
-                    'href' => route('show-donor', ['login_token' => $payload['donor']->login_token]),
-                    'target' => '_blank',
-                ],
-                icon: 'user',
-            ),
-            new DatatableActionDefinition(
                 key: 'invoice-create',
                 group: 'Rechnung',
                 label: 'Rechnung erstellen',

--- a/composer.json
+++ b/composer.json
@@ -122,10 +122,11 @@
     },
     "minimum-stability": "stable",
     "prefer-stable": true,
-    "repositories": {
-        "flux-pro": {
+    "repositories": [
+        {
+            "name": "flux-pro",
             "type": "composer",
             "url": "https://composer.fluxui.dev"
         }
-    }
+        ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcaf132fa844d07b671be2e91c3e746f",
+    "content-hash": "7ec4613f7d6886f991072cc9216971c4",
     "packages": [
         {
             "name": "bacon/bacon-qr-code",
@@ -14337,5 +14337,5 @@
         "ext-zip": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docker-compose.upgrade-lab.yml
+++ b/docker-compose.upgrade-lab.yml
@@ -26,8 +26,6 @@ services:
       MAIL_FROM_NAME: "HFM Upgrade Lab"
     volumes:
       - "${UPGRADE_LAB_APP_SOURCE:-.}:/var/www/html"
-      - /var/www/html/vendor
-      - /var/www/html/node_modules
     depends_on:
       db:
         condition: service_healthy

--- a/docker/upgrade-lab/app/Dockerfile
+++ b/docker/upgrade-lab/app/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update \
         opcache \
         pcntl \
         pdo_mysql \
+        sockets \
         zip \
     && a2enmod headers rewrite \
     && curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \

--- a/docs/plans/multi-event-restructure-plan.md
+++ b/docs/plans/multi-event-restructure-plan.md
@@ -127,15 +127,13 @@ Highest-risk coupling: `rounds_done` on athlete breaks per-year results. Partner
 
 ### Phase 3 — Refactor athletes/donors into external users
 
-> Replace the split `athletes` + `donors` identity + token-auth system with unified `external_users`, event-scoped `athlete_registrations`, and passwordless auth via signed URLs. No registrations are currently happening, so zero concurrent-write risk during migration. Migration window guarantee: no new `users`, `external_users`, `athletes`, `donors`, `athlete_registrations`, or `donations` until PR3 merge. Execute incrementally: add new schema/auth, backfill and switch reads, then remove legacy tables and token routes after validation.
+> Replace the split `athletes` + `donors` identity + token-auth system with unified `external_users`, event-scoped `athlete_registrations`, and passwordless auth via signed URLs. No registrations are currently happening, so zero concurrent-write risk during migration. Migration window guarantee: no new `users`, `external_users`, `athletes`, `donors`, `athlete_registrations`, or `donations` until the third pull request merge. Execute incrementally: add new schema/auth, backfill and switch reads, then remove legacy tables and token routes after validation.
 
-- [x] Create `external_users`, `athlete_registrations`, and new donation FKs without disrupting legacy reads
-- [x] Add external passwordless auth + split route files (`web`/`admin`/`portal`) with strict guard separation
-- [x] Add external signed login route `/portal/login/{uuid}` (15-minute temporary signed URL)
-- [x] Wire login form to include `external_users` signed-link path (legacy paths still active)
-- [ ] Keep `/portal` as placeholder page in PR1; switch to unified data view in PR2
-- [ ] Backfill identities, athlete registrations, and donation links; switch app reads to new models
-- [ ] Remove legacy `athletes`/`donors` tables, token routes, and fallback code after validation
+> Roll out this refactor in three deployable slices because each merged pull request auto-deploys. The sequence is additive foundation, validated data cutover, then legacy removal.
+
+- [x] Add the new external identity schema and passwordless auth foundation without disrupting legacy reads
+- [ ] Backfill legacy identities, participations, and donation links; then switch participant-facing reads to the new model
+- [ ] Remove legacy identity tables, token routes, and fallback code after validation
 
 ### Phase 4 — Groups, portal UI, event-scoped routes
 

--- a/docs/plans/refactor-athletes-donors-into-external-users.md
+++ b/docs/plans/refactor-athletes-donors-into-external-users.md
@@ -65,34 +65,34 @@ PR2 introduces one guarded migration command for this exact production data shap
 
 ### Command contract
 
-- [ ] Implement `php artisan hfm:backfill:external-users` with `--dry-run`.
-- [ ] Treat command as one-time guarded migration for this rollout, not generic dedupe engine.
-- [ ] Execute preflight before any write (including dry-run).
-- [ ] Write mode runs in one transaction and exits non-zero on violation.
-- [ ] No report file export; console output only.
-- [ ] Dry-run repeatable; write-mode rerun intentionally unsupported.
+- [x] Implement `php artisan hfm:backfill:external-users` with `--dry-run`.
+- [x] Treat command as one-time guarded migration for this rollout, not generic dedupe engine.
+- [x] Execute preflight before any write (including dry-run).
+- [x] Write mode runs in one transaction and exits non-zero on violation.
+- [x] No report file export; console output only.
+- [x] Dry-run repeatable; write-mode rerun intentionally unsupported.
 
 ### Preflight assumptions (fail-fast)
 
-- [ ] Duplicate normalized donor emails count is `0`.
-- [ ] Duplicate normalized athlete emails count is `0`.
-- [ ] Duplicate donation pair count for (`donor_id`, `athlete_id`) is `0`.
-- [ ] Every athlete has exactly one `donation_event_id`.
-- [ ] Every donation references existing donor and athlete.
-- [ ] `external_users`, `athlete_registrations`, and new donation FK columns are empty before write mode.
+- [x] Duplicate normalized donor emails count is `0`.
+- [x] Duplicate normalized athlete emails count is `0`.
+- [x] Duplicate donation pair count for (`donor_id`, `athlete_id`) is `0`.
+- [x] Every athlete has exactly one `donation_event_id`.
+- [x] Every donation references existing donor and athlete.
+- [x] `external_users`, `athlete_registrations`, and new donation FK columns are empty before write mode.
 
 If any check fails: print blocking counts, exit non-zero, write nothing.
 
 ### Backfill mapping rules
 
-- [ ] Normalize email with `trim(mb_strtolower($email))`.
-- [ ] Build `external_users` by normalized email only (no name/address/phone matching).
-- [ ] Same athlete+donor email becomes one dual-role `external_user`.
-- [ ] Dual-role merge policy: athlete fields win when both non-empty; fill athlete gaps from donor; keep donor-only `country_of_residence`.
-- [ ] Preserve migration trace via `legacy_athlete_id` / `legacy_donor_id`.
-- [ ] Create one `athlete_registration` per legacy athlete with copied event-scoped fields.
-- [ ] Map each donation to `donor_external_user_id` and `athlete_registration_id`.
-- [ ] Preserve donation row cardinality (1 legacy row -> 1 new-mapped row).
+- [x] Normalize email with `trim(mb_strtolower($email))`.
+- [x] Build `external_users` by normalized email only (no name/address/phone matching).
+- [x] Same athlete+donor email becomes one dual-role `external_user`.
+- [x] Dual-role merge policy: athlete fields win when both non-empty; fill athlete gaps from donor; keep donor-only `country_of_residence`.
+- [x] Preserve migration trace via `legacy_athlete_id` / `legacy_donor_id`.
+- [x] Create one `athlete_registration` per legacy athlete with copied event-scoped fields.
+- [x] Map each donation to `donor_external_user_id` and `athlete_registration_id`.
+- [x] Preserve donation row cardinality (1 legacy row -> 1 new-mapped row).
 
 ### Read switch scope
 
@@ -105,10 +105,10 @@ If any check fails: print blocking counts, exit non-zero, write nothing.
 ### Exit criteria
 
 - [ ] Rehearsal completed in upgrade lab using `storage/upgrade-lab/dumps/2026-05-17_16-44-51.sql` in dry-run and write mode.
-- [ ] Row parity checks pass.
-- [ ] Amount parity per event/donor passes (event derived via `athlete_registration`).
-- [ ] Every legacy athlete and donor maps to exactly one `external_user`.
-- [ ] Every donation resolves to exactly one `athlete_registration`.
+- [x] Row parity checks pass.
+- [x] Amount parity per event/donor passes (event derived via `athlete_registration`).
+- [x] Every legacy athlete and donor maps to exactly one `external_user`.
+- [x] Every donation resolves to exactly one `athlete_registration`.
 - [ ] Portal shows merged dual-role data grouped by donation event.
 - [ ] Legacy token redirects do not authenticate and do not mutate verification state.
 

--- a/docs/plans/refactor-athletes-donors-into-external-users.md
+++ b/docs/plans/refactor-athletes-donors-into-external-users.md
@@ -96,10 +96,10 @@ If any check fails: print blocking counts, exit non-zero, write nothing.
 
 ### Read switch scope
 
-- [ ] After successful backfill + validation, portal reads from `ExternalUser`, `AthleteRegistration`, and new donation FKs.
-- [ ] `LoginForm` normalizes input email and resolves `external_users` first.
-- [ ] Legacy token routes stop token auth and redirect to `/portal` with no side effects.
-- [ ] Remove admin token-login shortcuts that point to legacy token routes.
+- [x] After successful backfill + validation, portal reads from `ExternalUser`, `AthleteRegistration`, and new donation FKs.
+- [x] `LoginForm` normalizes input email and resolves `external_users` first.
+- [x] Legacy token routes stop token auth and redirect to `/portal` with no side effects.
+- [x] Remove admin token-login shortcuts that point to legacy token routes.
 - [ ] Keep admin list pages on legacy reads for PR2 (`admin/sportlerinnen`, `admin/spenderinnen`, `admin/spenden`).
 
 ### Exit criteria
@@ -109,8 +109,8 @@ If any check fails: print blocking counts, exit non-zero, write nothing.
 - [x] Amount parity per event/donor passes (event derived via `athlete_registration`).
 - [x] Every legacy athlete and donor maps to exactly one `external_user`.
 - [x] Every donation resolves to exactly one `athlete_registration`.
-- [ ] Portal shows merged dual-role data grouped by donation event.
-- [ ] Legacy token redirects do not authenticate and do not mutate verification state.
+- [x] Portal shows merged dual-role data grouped by donation event.
+- [x] Legacy token redirects do not authenticate and do not mutate verification state.
 
 ---
 

--- a/docs/plans/refactor-athletes-donors-into-external-users.md
+++ b/docs/plans/refactor-athletes-donors-into-external-users.md
@@ -1,146 +1,151 @@
 # Refactor Athletes/Donors into External Users
 
-> **Constraint: no registrations are currently happening.** Zero concurrent-write risk during migration. No time pressure — refactor incrementally at whatever pace ensures correctness.
->
-> **Extended guarantee for this migration window:** No new `users`, `external_users`, `athletes`, `donors`, `athlete_registrations`, or `donations` will be created between now and PR3 merge.
+## Context and rollout assumptions
 
-**Goal:** Replace the split `athletes` + `donors` identity + token-auth system with a unified `external_users` model, event-scoped `athlete_registrations`, and proper passwordless auth via signed URLs. After completion, the app behaves identically from a user perspective but is structurally prepared for multi-event features, groups, and future registration flows.
+- No concurrent writes during full migration window.
+- No new `users`, `external_users`, `athletes`, `donors`, `athlete_registrations`, or `donations` until PR3 merged.
+- No athlete or donor login activity until after PR3 merged.
+- Each PR merge auto-deploys.
+- PR2 operational step is mandatory: run `php artisan hfm:backfill:external-users` immediately after deployment.
+- Because assumptions above hold, transition can be strict and fail-fast.
 
-**Parent plan:** `docs/plans/multi-event-restructure-plan.md` — Section B defines the target data model; this document handles execution.
+## Goal
 
----
+Replace split `athletes` + `donors` identity and static token login with unified `external_users`, event-scoped `athlete_registrations`, and passwordless signed-URL auth. End-user behavior should stay effectively same, while model becomes ready for multi-event growth.
 
-## PR1 — New identity schema + auth + landing page
+Parent plan: `docs/plans/multi-event-restructure-plan.md` (Section B).
 
-> The new models and auth infrastructure exist and work, but the table is empty. Legacy paths remain fully operational. This PR makes the new world *possible* without disrupting the old.
-
-### Schema + models
-
-- [x] Create `external_users` migration + model (extends `Authenticatable` — no password column, passwordless login via signed URLs like admin `User`). Columns: `id`, `uuid` (unique, for signed URL routes), `first_name`, `last_name`, `address`, `zip_code`, `city`, `country_of_residence`, `phone_number`, `email` (unique), `public_id` (6-char uppercase alphanumeric, globally unique, always auto-generated, displayed as `XXX-XXX` to disambiguate athletes sharing the same privacy name), `remember_token`, timestamps, soft-deletes, `legacy_athlete_id` (nullable, migration trace), `legacy_donor_id` (nullable, migration trace)
-- [x] Create `athlete_registrations` migration + model. Columns: `id`, `donation_event_id` FK, `external_user_id` FK, `sport_type_id`, `partner_id` (nullable), `rounds_estimated`, `rounds_done`, `comment`, `verified`, timestamps. Constraints: unique (`donation_event_id`, `external_user_id`)
-- [x] Extend `donations` with nullable new columns: `donor_external_user_id`, `athlete_registration_id`. Event scope is derived through `athlete_registration.donation_event_id`; no redundant `donation_event_id` FK on donations. No `group_id` yet — added when groups are implemented. Keep old columns (`donor_id`, `athlete_id`) for compatibility
-
-### Auth infrastructure
-
-- [x] Configure `auth:external` guard + `external_users` provider in `config/auth.php`
-- [x] Split route files now: move admin routes to dedicated `routes/admin.php` (`auth:web`) and external portal routes to dedicated `routes/portal.php` (`auth:external`); keep public pages in `routes/web.php`
-- [x] Enforce strict guard separation via middleware (not Gates): `auth:external` cannot access admin routes; `auth:web` cannot access external write endpoints
-- [x] Add signed-URL login route for external users at `/portal/login/{uuid}` (controller action, no closure business logic), same pattern as admin `User`: `URL::temporarySignedRoute` → `auth()->guard('external')->login()` + session regeneration
-- [x] External signed login link TTL is 15 minutes and reusable within TTL (single-use invalidation out of scope)
-- [x] Update `LoginForm` to also check `external_users` table (dead path until backfill, but wired and ready). Legacy `Athlete`/`Donor` token lookups remain the active path
-
-### Landing page
-
-- [x] PR1 scope: keep `/portal` as placeholder-only page behind `auth:external` guard (no legacy-data merge, no verified status rendering yet)
-
-### Coexistence
-
-- [x] Legacy `/sportlerinnen/{token}` + `/spenderinnen/{token}` routes remain fully functional
-- [x] New `auth:external` routes exist in parallel — no disruption to existing users
-- [x] No legacy token-route redirects in PR1; redirects start only in PR2
-- [x] No new user-facing writes during this phase (no new `users`, `external_users`, `athletes`, `donors`, `athlete_registrations`, `donations`)
+Production rehearsal artifact: `storage/upgrade-lab/dumps/2026-05-17_16-44-51.sql`.
 
 ---
 
-## PR2 — Backfill + switch reads to new models
+## Current state
 
-> All legacy data lives in the new schema. The app reads from new models. Legacy tables become read-only fallback.
+- Identity split across `athletes` and `donors`.
+- External login relies on legacy static token routes.
+- `donations` references legacy foreign keys (`donor_id`, `athlete_id`).
+- Portal behavior depends on legacy models.
+- Admin pages read legacy tables.
 
-### Identity map (`athletes` + `donors` → `external_users`)
+## Target state (after PR3)
 
-- [ ] Build index of normalized emails across `athletes` + `donors` (`donors.email` may duplicate)
-- [ ] Unique emails across both tables → create one `external_users` row + attach all matching
-- [ ] Multiple `donors` with same email:
-  - [ ] Name + address identical → auto-merge, record all `legacy_donor_id`s
-  - [ ] Name or address differ → "donor-email-conflicts" manual-review CSV; resolve before hard cutover
-- [ ] Unmatched rows → create `external_users` keyed by name, address, phone
-- [ ] Persist mapping via `legacy_athlete_id`/`legacy_donor_id` trace columns on `external_users`
-
-### Backfill participations
-
-- [x] `donation_event` for each legacy athlete: `athletes.donation_event_id` backfilled via `BackfillAthleteEventAssignmentsCommand`
-- [ ] For each legacy athlete: create one `athlete_registration` from resolved `donation_event_id` + copy event-scoped fields (`rounds_estimated`, `rounds_done`, `verified`, legacy `partner_id`)
-
-### Backfill donations
-
-- [ ] For each legacy donation:
-  - [ ] Map `donor_id` → `donor_external_user_id`
-  - [ ] Map `athlete_id` → `athlete_registration_id`
-
-### Backfill command
-
-- [ ] Idempotent Artisan command `hfm:backfill:external-users` with `--dry-run` + report output (same pattern as `hfm:backfill:event-content`)
-- [ ] Validation checks after backfill: row count parity, amount parity per event/donor (event derived via athlete registration), every donation resolves to exactly one athlete registration, every legacy row mapped to exactly one external user
-
-### Switch reads
-
-- [ ] After backfill + validation: switch app reads to new models (`ExternalUser`, `AthleteRegistration`, donation queries via `donor_external_user_id`/`athlete_registration_id`)
-- [ ] `LoginForm` resolves `external_users` first; falls back to legacy `Athlete`/`Donor` token lookups
-- [ ] External-user landing page now shows real backfilled data
-- [ ] Build simple external-user landing page (combination of current athlete + donor detail views: greeting, list of donations-as-donor, list of donations-as-athlete, verified status)
-- [ ] Dual-role users see both athlete and donor sections in one page
-- [ ] Legacy token routes (`/sportlerinnen/{token}`, `/spenderinnen/{token}`) redirect to `/portal` — the same content is available there via `auth:external`
-- [ ] Welcome/registration notifications updated: send signed-URL login link (same pattern as admin) instead of legacy `/sportlerinnen/{token}` and `/spenderinnen/{token}` links (code-only change — no registrations happening currently)
-- [ ] QR codes in welcome letters encode the login page URL (no tokens in QR codes)
-- [ ] Legacy tables/columns become read-only fallback
-- [ ] Admin views (`admin/sportlerinnen`, `admin/spenderinnen`, `admin/spenden`) continue reading legacy tables during PR2 — admin rework happens in PR3 when legacy tables are dropped
+- Identity unified in `external_users` (passwordless signed login, `auth:external`).
+- Participation modeled as `athlete_registrations` scoped by `donation_event_id`.
+- `donations` linked via `donor_external_user_id` and `athlete_registration_id`.
+- Portal and admin read from new model graph.
+- Legacy token routes, models, and tables removed.
 
 ---
 
-## PR3 — Remove legacy
+## PR1 - Introduce new models and auth foundation
 
-> Clean break. No legacy code, tables, or token routes remain.
+### Steps
 
-- [ ] Enforce NOT NULL on new FKs (`donations.donor_external_user_id`, `donations.athlete_registration_id`)
-- [ ] Ensure `donations.athlete_registration_id` uses `RESTRICT` so athlete registrations with donations cannot be deleted
-- [ ] Remove old nullable columns from `donations`: `donor_id`, `athlete_id`
-- [ ] Drop legacy tables: `athletes`, `donors`
-- [ ] Remove legacy models: `Athlete`, `Donor`
-- [ ] Remove legacy token routes entirely (redirects from PR2 replaced with 404/removed)
-- [ ] Replace temporary transition guard in `Donation::boot()->created` with final new-schema flow (no legacy `donor` / `athlete` assumptions)
-- [ ] Remove `login_token` and `login_token_expiry_days` config
-- [ ] Remove `legacy_athlete_id`/`legacy_donor_id` trace columns from `external_users`
-- [ ] Remove legacy `LoginForm` fallback paths (only `external_users` lookup remains)
-- [ ] Switch admin views to new models (`admin/sportlerinnen` → athlete_registrations scoped by event, `admin/spenderinnen` → external_users with donor role, `admin/spenden` → donations via new FKs)
-- [ ] Login auditability: covered by `spatie/laravel-activitylog` (GH #111)
+- [x] Create `external_users` model + migration (`Authenticatable`, signed-URL login identity, trace columns `legacy_athlete_id`/`legacy_donor_id`).
+- [x] Create `athlete_registrations` model + migration with unique (`donation_event_id`, `external_user_id`).
+- [x] Extend `donations` with nullable `donor_external_user_id` and `athlete_registration_id` while keeping legacy columns.
+- [x] Configure `auth:external` guard + provider.
+- [x] Split routes into `routes/admin.php`, `routes/portal.php`, `routes/web.php` with strict guard separation.
+- [x] Add external signed login callback at `/portal/login/{uuid}` (controller action).
+- [x] Keep `/portal` as placeholder behind `auth:external`.
+- [x] Keep legacy token routes fully operational in parallel.
 
----
+### Exit criteria
 
-## Rollback + integrity
-
-- [ ] Rollback path: PR2 can revert to legacy reads; PR1 new schema is additive (no legacy disruption)
-- [ ] Integrity checks: row count parity, amount parity per event/donor (event derived via athlete registration), every donation resolves to exactly one athlete registration, every legacy row mapped to exactly one external user
+- [x] New schema exists and is additive only.
+- [x] Guard separation enforced by middleware.
+- [x] Signed external login flow works (valid + expired/invalid signature behavior covered).
+- [x] Placeholder portal renders without legacy data dependency.
 
 ---
 
-## Verification
+## PR2 - Backfill and switch portal reads
 
-### PR1 — Schema + auth
+PR2 introduces one guarded migration command for this exact production data shape, then flips portal reads.
 
-- [x] `external_users` uniqueness/dedup behavior
-- [x] `athlete_registrations` unique per (`event`, `external_user`)
-- [x] External login resolves one portal for dual-role user
-- [x] External guard **cannot** access admin routes (enforced by middleware, tested per route)
-- [x] Internal guard **cannot** access external write endpoints
-- [x] Route split verified: admin routes are loaded from `routes/admin.php`, portal routes from `routes/portal.php`, and public routes from `routes/web.php`
-- [x] External signed-login callback uses `/portal/login/{uuid}` controller action; signed URL expiry and invalid signature are tested
-- [x] Placeholder `/portal` page renders for authenticated external users without legacy athlete/donor dependency
+### Command contract
 
-### PR2 — Backfill + switch reads
+- [ ] Implement `php artisan hfm:backfill:external-users` with `--dry-run`.
+- [ ] Treat command as one-time guarded migration for this rollout, not generic dedupe engine.
+- [ ] Execute preflight before any write (including dry-run).
+- [ ] Write mode runs in one transaction and exits non-zero on violation.
+- [ ] No report file export; console output only.
+- [ ] Dry-run repeatable; write-mode rerun intentionally unsupported.
 
-- [ ] Backfill parity checks for counts and sums
-- [ ] Conflict fixture test (same email, differing names) requires manual resolution path
-- [ ] Dry-run migration reports identity merge decisions
-- [ ] 100% legacy athlete/donor rows mapped to exactly one external user
-- [ ] Per-event financial totals match baseline
-- [ ] Donor can sponsor same athlete in different events
-- [ ] Event-scoped results/dashboard totals are isolated
-- [ ] Portal page switches from placeholder to real merged donor/athlete data after backfill
+### Preflight assumptions (fail-fast)
 
-### PR3 — Legacy removal
+- [ ] Duplicate normalized donor emails count is `0`.
+- [ ] Duplicate normalized athlete emails count is `0`.
+- [ ] Duplicate donation pair count for (`donor_id`, `athlete_id`) is `0`.
+- [ ] Every athlete has exactly one `donation_event_id`.
+- [ ] Every donation references existing donor and athlete.
+- [ ] `external_users`, `athlete_registrations`, and new donation FK columns are empty before write mode.
 
-- [ ] Old token routes (`/sportlerinnen/{token}`, `/spenderinnen/{token}`) return 404
-- [ ] Admin views work with new models (athlete_registrations, external_users, donations via new FKs)
-- [ ] Admin pages remain internal-only; event switching yields consistent counts
-- [ ] Invoice generation works with event filter
-- [ ] External auth uses same passwordless login page as admin users (email → signed URL) with `auth:external` guard; mandatory guard separation enforced
+If any check fails: print blocking counts, exit non-zero, write nothing.
+
+### Backfill mapping rules
+
+- [ ] Normalize email with `trim(mb_strtolower($email))`.
+- [ ] Build `external_users` by normalized email only (no name/address/phone matching).
+- [ ] Same athlete+donor email becomes one dual-role `external_user`.
+- [ ] Dual-role merge policy: athlete fields win when both non-empty; fill athlete gaps from donor; keep donor-only `country_of_residence`.
+- [ ] Preserve migration trace via `legacy_athlete_id` / `legacy_donor_id`.
+- [ ] Create one `athlete_registration` per legacy athlete with copied event-scoped fields.
+- [ ] Map each donation to `donor_external_user_id` and `athlete_registration_id`.
+- [ ] Preserve donation row cardinality (1 legacy row -> 1 new-mapped row).
+
+### Read switch scope
+
+- [ ] After successful backfill + validation, portal reads from `ExternalUser`, `AthleteRegistration`, and new donation FKs.
+- [ ] `LoginForm` normalizes input email and resolves `external_users` first.
+- [ ] Legacy token routes stop token auth and redirect to `/portal` with no side effects.
+- [ ] Remove admin token-login shortcuts that point to legacy token routes.
+- [ ] Keep admin list pages on legacy reads for PR2 (`admin/sportlerinnen`, `admin/spenderinnen`, `admin/spenden`).
+
+### Exit criteria
+
+- [ ] Rehearsal completed in upgrade lab using `storage/upgrade-lab/dumps/2026-05-17_16-44-51.sql` in dry-run and write mode.
+- [ ] Row parity checks pass.
+- [ ] Amount parity per event/donor passes (event derived via `athlete_registration`).
+- [ ] Every legacy athlete and donor maps to exactly one `external_user`.
+- [ ] Every donation resolves to exactly one `athlete_registration`.
+- [ ] Portal shows merged dual-role data grouped by donation event.
+- [ ] Legacy token redirects do not authenticate and do not mutate verification state.
+
+---
+
+## PR3 - Remove legacy and complete switch
+
+### Steps
+
+- [ ] Enforce NOT NULL on `donations.donor_external_user_id` and `donations.athlete_registration_id`.
+- [ ] Ensure delete rule for `donations.athlete_registration_id` is `RESTRICT`.
+- [ ] Remove legacy donation columns `donor_id`, `athlete_id`.
+- [ ] Drop legacy tables `athletes`, `donors`.
+- [ ] Remove legacy models `Athlete`, `Donor`.
+- [ ] Remove legacy token routes entirely (no transition redirects).
+- [ ] Remove legacy login-token config keys.
+- [ ] Remove `legacy_athlete_id` / `legacy_donor_id` trace columns.
+- [ ] Remove legacy `LoginForm` fallback paths.
+- [ ] Switch admin pages to new models and FKs.
+
+### Exit criteria
+
+- [ ] Legacy token route paths return 404.
+- [ ] Admin pages work on new model graph with consistent event-scoped counts.
+- [ ] External passwordless login remains functional through shared login entry.
+- [ ] No remaining runtime dependency on `athletes` or `donors`.
+
+---
+
+## Rollback and risk posture
+
+- [ ] PR1 is additive and low risk.
+- [ ] PR2 rollback path is read-switch revert to legacy reads if needed.
+- [ ] PR3 is clean break and should ship only after PR2 validations pass.
+
+## Out of scope for this refactor
+
+- [ ] Generic cross-environment dedupe engine.
+- [ ] New registration flows.
+- [ ] Group model and group-level sponsorship behavior.

--- a/docs/plans/refactor-athletes-donors-into-external-users.md
+++ b/docs/plans/refactor-athletes-donors-into-external-users.md
@@ -100,11 +100,11 @@ If any check fails: print blocking counts, exit non-zero, write nothing.
 - [x] `LoginForm` normalizes input email and resolves `external_users` first.
 - [x] Legacy token routes stop token auth and redirect to `/portal` with no side effects.
 - [x] Remove admin token-login shortcuts that point to legacy token routes.
-- [ ] Keep admin list pages on legacy reads for PR2 (`admin/sportlerinnen`, `admin/spenderinnen`, `admin/spenden`).
+- [x] Keep admin list pages on legacy reads for PR2 (`admin/sportlerinnen`, `admin/spenderinnen`, `admin/spenden`).
 
 ### Exit criteria
 
-- [ ] Rehearsal completed in upgrade lab using `storage/upgrade-lab/dumps/2026-05-17_16-44-51.sql` in dry-run and write mode.
+- [x] Rehearsal completed in upgrade lab using `storage/upgrade-lab/dumps/2026-05-17_16-44-51.sql` in dry-run and write mode.
 - [x] Row parity checks pass.
 - [x] Amount parity per event/donor passes (event derived via `athlete_registration`).
 - [x] Every legacy athlete and donor maps to exactly one `external_user`.

--- a/peck.json
+++ b/peck.json
@@ -64,7 +64,8 @@
             "iban",
             "twint",
             "fn",
-            "hardcoded"
+            "hardcoded",
+            "preflight"
         ],
         "paths": []
     }

--- a/resources/views/components/admin/tables/athlete-table.blade.php
+++ b/resources/views/components/admin/tables/athlete-table.blade.php
@@ -159,7 +159,6 @@
                                 <flux:menu>
                                     <flux:menu.item wire:click="downloadWelcomeLetter({{ $athlete->id }})">Brief</flux:menu.item>
                                     <flux:menu.item wire:click="downloadPersonalizedFlyerTemplate({{ $athlete->id }})">Flyer</flux:menu.item>
-                                    <flux:menu.item :href="route('show-athlete', ['login_token' => $athlete->login_token])" target="_blank">Login</flux:menu.item>
                                 </flux:menu>
                             </flux:dropdown>
                         </x-admin.tables.partials.actions-column>

--- a/resources/views/pages/portal.blade.php
+++ b/resources/views/pages/portal.blade.php
@@ -3,17 +3,70 @@
 @section('content')
     <x-page-title>Portal</x-page-title>
 
-    <div class="w-full max-w-2xl mx-auto space-y-4 text-left sm:text-center">
-        <p>
-            {{ auth('external')->user()?->first_name ? 'Hallo '.auth('external')->user()->first_name : 'Hallo' }}
+    <div class="w-full max-w-4xl mx-auto space-y-10 text-left">
+        <p class="text-center">
+            {{ $externalUser->first_name !== '' ? 'Hallo '.$externalUser->first_name : 'Hallo' }}
         </p>
 
-        <p>
-            Willkommen im neuen Portal.
-        </p>
+        <section class="space-y-4">
+            <x-page-subtitle>Ich bin Sportler:in</x-page-subtitle>
 
-        <p class="text-sm text-zinc-600 dark:text-zinc-300">
-            Diese Seite ist aktuell in Aufbau. Deine Sportler:innen- und Spender:innen-Daten bleiben bis zur Umstellung weiterhin unter den bestehenden Links erreichbar.
-        </p>
+            @if ($athleteRegistrationsByEvent->isEmpty())
+                <p>Du hast aktuell keine Sportler:innen-Anmeldungen im Portal.</p>
+            @else
+                @foreach ($athleteRegistrationsByEvent as $eventId => $registrations)
+                    <div class="space-y-3">
+                        <x-page-subsubtitle>{{ $eventTitles[$eventId] ?? 'Unbekannter Event' }}</x-page-subsubtitle>
+                        <ul role="list" class="divide-y divide-gray-900/10 dark:divide-gray-100/30">
+                            @foreach ($registrations as $registration)
+                                <li class="py-4 space-y-2">
+                                    <div class="flex flex-wrap justify-between gap-2">
+                                        <span class="font-semibold">{{ $registration->sportType?->name }}</span>
+                                        <span class="text-sm text-gray-500">Verifiziert: {{ $registration->verified ? 'Ja' : 'Nein' }}</span>
+                                    </div>
+
+                                    @if ($registration->donations->isEmpty())
+                                        <p class="text-sm text-gray-500">Noch keine Spenden für diesen Event.</p>
+                                    @else
+                                        <ul class="space-y-2 text-sm">
+                                            @foreach ($registration->donations as $donation)
+                                                <li class="flex flex-wrap justify-between gap-2">
+                                                    <span>{{ $donation->donorExternalUser?->privacy_name ?? 'Unbekannte:r Spender:in' }}</span>
+                                                    <span>Fr. {{ sprintf('%1.2f', $donation->amount_per_round) }} / Runde</span>
+                                                </li>
+                                            @endforeach
+                                        </ul>
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endforeach
+            @endif
+        </section>
+
+        <section class="space-y-4">
+            <x-page-subtitle>Ich spende</x-page-subtitle>
+
+            @if ($donationsAsDonorByEvent->isEmpty())
+                <p>Du hast aktuell keine Spenden im Portal.</p>
+            @else
+                @foreach ($donationsAsDonorByEvent as $eventId => $donations)
+                    <div class="space-y-3">
+                        <x-page-subsubtitle>{{ $eventTitles[$eventId] ?? 'Unbekannter Event' }}</x-page-subsubtitle>
+                        <ul role="list" class="divide-y divide-gray-900/10 dark:divide-gray-100/30">
+                            @foreach ($donations as $donation)
+                                <li class="py-4 flex flex-wrap justify-between gap-2">
+                                    <span>
+                                        {{ $donation->athleteRegistration?->externalUser?->privacy_name ?? 'Unbekannte:r Sportler:in' }}
+                                    </span>
+                                    <span>Fr. {{ sprintf('%1.2f', $donation->amount_per_round) }} / Runde</span>
+                                </li>
+                            @endforeach
+                        </ul>
+                    </div>
+                @endforeach
+            @endif
+        </section>
     </div>
 @endsection

--- a/routes/portal.php
+++ b/routes/portal.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ExternalUserSessionController;
+use App\Http\Controllers\PortalController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('portal/login/{uuid}', [ExternalUserSessionController::class, 'store'])
@@ -9,7 +10,7 @@ Route::get('portal/login/{uuid}', [ExternalUserSessionController::class, 'store'
     ->whereUuid('uuid');
 
 Route::middleware('auth:external')->group(function (): void {
-    Route::view('portal', 'pages.portal')->name('portal.dashboard');
+    Route::get('portal', PortalController::class)->name('portal.dashboard');
 
     Route::post('portal/logout', [ExternalUserSessionController::class, 'destroy'])->name('portal.logout');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,8 +4,7 @@ use App\Http\Controllers\AdminSessionController;
 use App\Http\Controllers\FaqController;
 use App\Http\Controllers\HomeController;
 use App\Http\Controllers\NewsletterSubscriptionController;
-use Illuminate\Contracts\View\Factory;
-use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Route;
 
@@ -50,24 +49,17 @@ Route::get('login/{uuid}', [AdminSessionController::class, 'store'])
     ->whereUuid('uuid');
 
 // Athlete
-Route::get('sportlerinnen/{login_token}', function ($login_token): Factory|View {
-    return view('pages.show-athlete', [
-        'login_token' => $login_token,
-    ]);
+Route::get('sportlerinnen/{login_token}', function (): RedirectResponse {
+    return to_route('portal.dashboard');
 })->name('show-athlete');
 
 // Donor
-Route::get('spenderinnen/{login_token}', function ($login_token): Factory|View {
-    return view('pages.show-donor', [
-        'login_token' => $login_token,
-    ]);
+Route::get('spenderinnen/{login_token}', function (): RedirectResponse {
+    return to_route('portal.dashboard');
 })->name('show-donor');
 
-Route::get('spenderinnen/{login_token}/{donation_id}', function ($login_token, $donation_id): Factory|View {
-    return view('pages.show-donor', [
-        'login_token' => $login_token,
-        'donation_id' => $donation_id,
-    ]);
+Route::get('spenderinnen/{login_token}/{donation_id}', function (): RedirectResponse {
+    return to_route('portal.dashboard');
 })->name('verify-donation');
 
 Route::get('queue-worker', function (): string {

--- a/scripts/upgrade-lab
+++ b/scripts/upgrade-lab
@@ -41,20 +41,13 @@ Notes:
   - Release-specific commands (backfills, data migrations) are run manually
     on the container during the post-deploy pause.
   - Mail is routed to Mailpit in the lab stack for login-link checks.
-  - Uses Sail on Linux/macOS when available, otherwise falls back to docker compose.
+  - Uses docker compose directly.
 EOF
 }
 
 fail() {
     printf 'ERROR: %s\n' "$1" >&2
     exit 1
-}
-
-is_sail_supported() {
-    case "$(uname -s)" in
-        Linux*|Darwin*) return 0 ;;
-        *) return 1 ;;
-    esac
 }
 
 is_absolute_path() {
@@ -145,17 +138,7 @@ export COMPOSE_PROJECT_NAME="$UPGRADE_LAB_PROJECT_NAME"
 
 MAILPIT_UI_URL="http://localhost:$UPGRADE_LAB_MAILPIT_UI_PORT"
 
-USE_SAIL=0
-if [[ -x "$ROOT_DIR/vendor/bin/sail" ]] && is_sail_supported; then
-    USE_SAIL=1
-fi
-
 compose_cmd() {
-    if [[ "$USE_SAIL" -eq 1 ]]; then
-        "$ROOT_DIR/vendor/bin/sail" -f "$COMPOSE_FILE" "$@"
-        return
-    fi
-
     docker compose --project-name "$UPGRADE_LAB_PROJECT_NAME" -f "$COMPOSE_FILE" "$@"
 }
 
@@ -201,7 +184,6 @@ wait_for_app() {
 }
 
 prepare_worktree_runtime_artifacts() {
-    compose_cmd exec -T app sh -c 'find vendor -mindepth 1 -delete 2>/dev/null; find node_modules -mindepth 1 -delete 2>/dev/null; true'
     compose_cmd exec -T app composer install --no-interaction --prefer-dist --optimize-autoloader
 
     if compose_cmd exec -T app test -f package-lock.json; then

--- a/tests/Feature/AuthInfrastructureTest.php
+++ b/tests/Feature/AuthInfrastructureTest.php
@@ -155,7 +155,7 @@ it('registers split route files with expected guard middleware', function () {
     expect($homeRoute->middleware())->not->toContain('auth:external');
 });
 
-it('renders placeholder portal page for authenticated external users without legacy records', function () {
+it('renders portal page for authenticated external users without registrations or donations', function () {
     $externalUser = ExternalUser::factory()->create([
         'first_name' => 'Alex',
     ]);
@@ -164,6 +164,8 @@ it('renders placeholder portal page for authenticated external users without leg
         ->get(route('portal.dashboard'))
         ->assertSuccessful()
         ->assertSeeText('Hallo Alex')
-        ->assertSeeText('Willkommen im neuen Portal.')
-        ->assertSeeText('Diese Seite ist aktuell in Aufbau.');
+        ->assertSeeText('Ich bin Sportler:in')
+        ->assertSeeText('Ich spende')
+        ->assertSeeText('Du hast aktuell keine Sportler:innen-Anmeldungen im Portal.')
+        ->assertSeeText('Du hast aktuell keine Spenden im Portal.');
 });

--- a/tests/Feature/BackfillExternalUsersCommandTest.php
+++ b/tests/Feature/BackfillExternalUsersCommandTest.php
@@ -1,0 +1,432 @@
+<?php
+
+use App\Console\Commands\BackfillExternalUsersCommand;
+use App\Models\Athlete;
+use App\Models\AthleteRegistration;
+use App\Models\Donation;
+use App\Models\DonationEvent;
+use App\Models\Donor;
+use App\Models\ExternalUser;
+use App\Models\Partner;
+use App\Models\SportType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Tester\CommandTester;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $this->event = DonationEvent::factory()->create();
+    $this->partner = Partner::factory()->create();
+    $this->sportType = SportType::query()->create([
+        'name' => 'Laufen',
+    ]);
+});
+
+describe('preflight blockers', function () {
+    it('fails on blocker and performs no writes in write mode', function (Closure $seedBlocker, string $expectedOutput): void {
+        seedHappyPath($this);
+        $seedBlocker($this);
+
+        $this->artisan('hfm:backfill:external-users')
+            ->expectsOutputToContain($expectedOutput)
+            ->assertFailed();
+
+        assertNoNewSchemaWrites();
+    })->with([
+        'duplicate normalized donor emails' => [
+            function (): void {
+                Donor::factory()->create(['email' => 'Person@example.com']);
+                Donor::factory()->create(['email' => ' person@example.com ']);
+            },
+            'Duplicate normalized donor emails found.',
+        ],
+        'duplicate normalized athlete emails' => [
+            function (object $testCase): void {
+                Athlete::factory()->create([
+                    'donation_event_id' => $testCase->event->id,
+                    'partner_id' => $testCase->partner->id,
+                    'sport_type_id' => $testCase->sportType->id,
+                    'email' => 'Athlete@example.com',
+                ]);
+
+                Athlete::factory()->create([
+                    'donation_event_id' => $testCase->event->id,
+                    'partner_id' => $testCase->partner->id,
+                    'sport_type_id' => $testCase->sportType->id,
+                    'email' => ' athlete@example.com ',
+                ]);
+            },
+            'Duplicate normalized athlete emails found.',
+        ],
+        'duplicate legacy donation pairs' => [
+            function (object $testCase): void {
+                $athlete = Athlete::factory()->create([
+                    'donation_event_id' => $testCase->event->id,
+                    'partner_id' => $testCase->partner->id,
+                    'sport_type_id' => $testCase->sportType->id,
+                ]);
+                $donor = Donor::factory()->create();
+
+                Donation::query()->create([
+                    'donor_id' => $donor->id,
+                    'athlete_id' => $athlete->id,
+                    'amount_per_round' => 5,
+                    'amount_max' => 50,
+                    'amount_min' => 10,
+                    'comment' => null,
+                    'verified' => false,
+                ]);
+
+                Donation::query()->create([
+                    'donor_id' => $donor->id,
+                    'athlete_id' => $athlete->id,
+                    'amount_per_round' => 7,
+                    'amount_max' => 60,
+                    'amount_min' => 10,
+                    'comment' => null,
+                    'verified' => false,
+                ]);
+            },
+            'Duplicate legacy donation pairs (donor_id, athlete_id) found.',
+        ],
+        'athletes missing donation event' => [
+            function (object $testCase): void {
+                Athlete::factory()->create([
+                    'donation_event_id' => null,
+                    'partner_id' => $testCase->partner->id,
+                    'sport_type_id' => $testCase->sportType->id,
+                ]);
+            },
+            'Athletes without donation_event_id found.',
+        ],
+        'donors with blank normalized email' => [
+            function (): void {
+                Donor::factory()->create(['email' => '   ']);
+            },
+            'Donors with blank normalized emails found.',
+        ],
+        'athletes with blank normalized email' => [
+            function (object $testCase): void {
+                Athlete::factory()->create([
+                    'donation_event_id' => $testCase->event->id,
+                    'partner_id' => $testCase->partner->id,
+                    'sport_type_id' => $testCase->sportType->id,
+                    'email' => '   ',
+                ]);
+            },
+            'Athletes with blank normalized emails found.',
+        ],
+    ]);
+
+    it('fails in dry-run and write mode when target schema not empty', function (): void {
+        seedHappyPath($this);
+
+        ExternalUser::factory()->create();
+
+        $this->artisan('hfm:backfill:external-users --dry-run')
+            ->expectsOutputToContain('Target tables/columns are not empty.')
+            ->assertFailed();
+
+        $this->artisan('hfm:backfill:external-users')
+            ->expectsOutputToContain('Target tables/columns are not empty.')
+            ->assertFailed();
+    });
+});
+
+describe('dry-run contract', function () {
+    it('passes preflight prints preview and performs no writes', function (): void {
+        Athlete::factory()->create([
+            'donation_event_id' => $this->event->id,
+            'partner_id' => $this->partner->id,
+            'sport_type_id' => $this->sportType->id,
+            'email' => 'preview-athlete@example.com',
+        ]);
+
+        Donor::factory()->create([
+            'email' => 'preview-donor@example.com',
+        ]);
+
+        $this->artisan('hfm:backfill:external-users --dry-run')
+            ->expectsOutputToContain('Preflight passed. Safe to write.')
+            ->expectsOutputToContain('Dry run: write phase not executed.')
+            ->expectsOutputToContain('Dry-run merge preview:')
+            ->expectsOutputToContain('preview-athlete@example.com => athlete:')
+            ->expectsOutputToContain('preview-donor@example.com => athlete:- donor:')
+            ->assertSuccessful();
+
+        assertNoNewSchemaWrites();
+    });
+});
+
+describe('write mode contract', function () {
+    it('backfills external users athlete registrations and donation mappings', function (): void {
+        $athlete = Athlete::factory()->create([
+            'donation_event_id' => $this->event->id,
+            'partner_id' => $this->partner->id,
+            'sport_type_id' => $this->sportType->id,
+            'email' => 'athlete@example.com',
+        ]);
+
+        $donor = Donor::factory()->create([
+            'email' => 'donor@example.com',
+        ]);
+
+        $donation = Donation::query()->create([
+            'donor_id' => $donor->id,
+            'athlete_id' => $athlete->id,
+            'amount_per_round' => 12,
+            'amount_max' => 120,
+            'amount_min' => 0,
+            'comment' => 'Go!',
+            'verified' => true,
+        ]);
+
+        $this->artisan('hfm:backfill:external-users')
+            ->expectsOutputToContain('Backfill write completed successfully.')
+            ->assertSuccessful();
+
+        expect(ExternalUser::query()->count())->toBe(2);
+
+        $athleteExternal = ExternalUser::query()->where('legacy_athlete_id', $athlete->id)->first();
+        $donorExternal = ExternalUser::query()->where('legacy_donor_id', $donor->id)->first();
+
+        expect($athleteExternal)->not->toBeNull();
+        expect($donorExternal)->not->toBeNull();
+
+        $registration = AthleteRegistration::query()
+            ->where('external_user_id', $athleteExternal->id)
+            ->first();
+
+        expect($registration)->not->toBeNull();
+        expect($registration->donation_event_id)->toBe($this->event->id);
+
+        $donation->refresh();
+        expect($donation->donor_external_user_id)->toBe($donorExternal->id);
+        expect($donation->athlete_registration_id)->toBe($registration->id);
+    });
+
+    it('write mode is non-rerunnable and fails when target schema already filled', function (): void {
+        seedHappyPath($this);
+
+        $this->artisan('hfm:backfill:external-users')->assertSuccessful();
+
+        $this->artisan('hfm:backfill:external-users')
+            ->expectsOutputToContain('Target tables/columns are not empty.')
+            ->assertFailed();
+    });
+
+    it('rolls back all writes when post-write parity validation fails', function (): void {
+        seedHappyPath($this);
+
+        $command = new class extends BackfillExternalUsersCommand
+        {
+            protected function validatePostWriteParity(): void
+            {
+                throw new RuntimeException('Parity check failed for rollback test.');
+            }
+        };
+
+        $command->setLaravel($this->app);
+        $tester = new CommandTester($command);
+
+        expect(fn (): int => $tester->execute([]))
+            ->toThrow(RuntimeException::class, 'Parity check failed for rollback test.');
+
+        assertNoNewSchemaWrites();
+    });
+});
+
+describe('identity mapping rules', function () {
+    it('merges dual-role user by normalized email and prefers athlete profile fields', function (): void {
+        $athlete = Athlete::factory()->create([
+            'donation_event_id' => $this->event->id,
+            'partner_id' => $this->partner->id,
+            'sport_type_id' => $this->sportType->id,
+            'email' => 'DualRole@example.com',
+            'first_name' => 'AthleteFirst',
+            'last_name' => 'AthleteLast',
+            'address' => 'Athlete Street 1',
+            'zip_code' => 8400,
+            'city' => 'Winterthur',
+            'phone_number' => '+41 11 111 11 11',
+        ]);
+
+        $donor = Donor::factory()->create([
+            'email' => ' dualrole@example.com ',
+            'first_name' => 'DonorFirst',
+            'last_name' => 'DonorLast',
+            'address' => 'Donor Street 2',
+            'zip_code' => '9999',
+            'city' => 'Zurich',
+            'phone_number' => '+41 22 222 22 22',
+            'country_of_residence' => 'DE',
+        ]);
+
+        $this->artisan('hfm:backfill:external-users')->assertSuccessful();
+
+        expect(ExternalUser::query()->count())->toBe(1);
+
+        $externalUser = ExternalUser::query()->firstOrFail();
+
+        expect($externalUser->legacy_athlete_id)->toBe($athlete->id)
+            ->and($externalUser->legacy_donor_id)->toBe($donor->id)
+            ->and($externalUser->email)->toBe('dualrole@example.com')
+            ->and($externalUser->first_name)->toBe('AthleteFirst')
+            ->and($externalUser->last_name)->toBe('AthleteLast')
+            ->and($externalUser->address)->toBe('Athlete Street 1')
+            ->and($externalUser->zip_code)->toBe('8400')
+            ->and($externalUser->city)->toBe('Winterthur')
+            ->and($externalUser->phone_number)->toBe('+41 11 111 11 11')
+            ->and($externalUser->country_of_residence)->toBe('DE')
+            ->and(Str::length($externalUser->public_id))->toBe(6);
+    });
+
+    it('fills missing athlete profile fields from donor data for dual-role users', function (): void {
+        Athlete::factory()->create([
+            'donation_event_id' => $this->event->id,
+            'partner_id' => $this->partner->id,
+            'sport_type_id' => $this->sportType->id,
+            'email' => 'fill@example.com',
+            'first_name' => 'AthleteFirst',
+            'last_name' => 'AthleteLast',
+            'address' => '',
+            'city' => '',
+            'phone_number' => '',
+        ]);
+
+        Donor::factory()->create([
+            'email' => ' fill@example.com ',
+            'address' => 'Donor Address 3',
+            'zip_code' => '7777',
+            'city' => 'Bern',
+            'phone_number' => '+41 33 333 33 33',
+            'country_of_residence' => 'AT',
+        ]);
+
+        $this->artisan('hfm:backfill:external-users')->assertSuccessful();
+
+        $externalUser = ExternalUser::query()->firstOrFail();
+
+        expect($externalUser->first_name)->toBe('AthleteFirst')
+            ->and($externalUser->last_name)->toBe('AthleteLast')
+            ->and($externalUser->address)->toBe('Donor Address 3')
+            ->and($externalUser->city)->toBe('Bern')
+            ->and($externalUser->phone_number)->toBe('+41 33 333 33 33')
+            ->and($externalUser->country_of_residence)->toBe('AT');
+    });
+
+    it('creates independent external users for unmatched athlete-only and donor-only rows', function (): void {
+        $athleteOnly = Athlete::factory()->create([
+            'donation_event_id' => $this->event->id,
+            'partner_id' => $this->partner->id,
+            'sport_type_id' => $this->sportType->id,
+            'email' => 'athlete-only@example.com',
+        ]);
+
+        $donorOnly = Donor::factory()->create([
+            'email' => 'donor-only@example.com',
+        ]);
+
+        $this->artisan('hfm:backfill:external-users')->assertSuccessful();
+
+        $athleteExternal = ExternalUser::query()->where('legacy_athlete_id', $athleteOnly->id)->first();
+        $donorExternal = ExternalUser::query()->where('legacy_donor_id', $donorOnly->id)->first();
+
+        expect($athleteExternal)->not->toBeNull()
+            ->and($athleteExternal->legacy_donor_id)->toBeNull()
+            ->and($athleteExternal->country_of_residence)->toBe('CH')
+            ->and($donorExternal)->not->toBeNull()
+            ->and($donorExternal->legacy_athlete_id)->toBeNull();
+    });
+});
+
+describe('post-write integrity criteria', function () {
+    it('preserves grouped amount parity by event and donor', function (): void {
+        $eventA = DonationEvent::factory()->create();
+        $eventB = DonationEvent::factory()->create();
+
+        $athleteA = Athlete::factory()->create([
+            'donation_event_id' => $eventA->id,
+            'partner_id' => $this->partner->id,
+            'sport_type_id' => $this->sportType->id,
+            'email' => 'a-athlete@example.com',
+        ]);
+
+        $athleteB = Athlete::factory()->create([
+            'donation_event_id' => $eventB->id,
+            'partner_id' => $this->partner->id,
+            'sport_type_id' => $this->sportType->id,
+            'email' => 'b-athlete@example.com',
+        ]);
+
+        $donor = Donor::factory()->create(['email' => 'parity-donor@example.com']);
+
+        Donation::query()->create([
+            'donor_id' => $donor->id,
+            'athlete_id' => $athleteA->id,
+            'amount_per_round' => 10,
+            'amount_max' => 100,
+            'amount_min' => 0,
+            'verified' => false,
+        ]);
+
+        Donation::query()->create([
+            'donor_id' => $donor->id,
+            'athlete_id' => $athleteB->id,
+            'amount_per_round' => 12,
+            'amount_max' => 120,
+            'amount_min' => 0,
+            'verified' => false,
+        ]);
+
+        $this->artisan('hfm:backfill:external-users')->assertSuccessful();
+
+        $legacyByEvent = Donation::query()
+            ->join('athletes', 'athletes.id', '=', 'donations.athlete_id')
+            ->selectRaw('athletes.donation_event_id as event_id, SUM(donations.amount_per_round) as total')
+            ->groupBy('athletes.donation_event_id')
+            ->pluck('total', 'event_id');
+
+        $newByEvent = Donation::query()
+            ->join('athlete_registrations', 'athlete_registrations.id', '=', 'donations.athlete_registration_id')
+            ->selectRaw('athlete_registrations.donation_event_id as event_id, SUM(donations.amount_per_round) as total')
+            ->groupBy('athlete_registrations.donation_event_id')
+            ->pluck('total', 'event_id');
+
+        expect($newByEvent->all())->toBe($legacyByEvent->all());
+    });
+});
+
+function seedHappyPath(object $testCase): array
+{
+    $athlete = Athlete::factory()->create([
+        'donation_event_id' => $testCase->event->id,
+        'partner_id' => $testCase->partner->id,
+        'sport_type_id' => $testCase->sportType->id,
+        'email' => 'baseline-athlete@example.com',
+    ]);
+
+    $donor = Donor::factory()->create([
+        'email' => 'baseline-donor@example.com',
+    ]);
+
+    $donation = Donation::query()->create([
+        'donor_id' => $donor->id,
+        'athlete_id' => $athlete->id,
+        'amount_per_round' => 9,
+        'amount_max' => 90,
+        'amount_min' => 0,
+        'verified' => false,
+    ]);
+
+    return [$athlete, $donor, $donation];
+}
+
+function assertNoNewSchemaWrites(): void
+{
+    expect(ExternalUser::query()->count())->toBe(0)
+        ->and(AthleteRegistration::query()->count())->toBe(0)
+        ->and(Donation::query()->whereNotNull('donor_external_user_id')->count())->toBe(0)
+        ->and(Donation::query()->whereNotNull('athlete_registration_id')->count())->toBe(0);
+}

--- a/tests/Feature/Components/DatatableBaseComponentTest.php
+++ b/tests/Feature/Components/DatatableBaseComponentTest.php
@@ -8,7 +8,10 @@ use App\Models\Donation;
 use App\Models\Donor;
 use App\Models\Partner;
 use App\Models\SportType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
 
 it('normalizes invalid donor sorting input using shared allowlist validation', function (): void {
     $later = Donor::factory()->create(['first_name' => 'Zoe']);
@@ -266,7 +269,7 @@ it('builds donor row action groups and keeps overdue reminder visibility', funct
 
     $invoiceKeys = collect($groups['Rechnung'] ?? [])->pluck('key')->all();
 
-    expect($groups)->toHaveKeys(['Spender:in', 'Rechnung']);
+    expect(array_keys($groups))->toBe(['Rechnung']);
     expect($invoiceKeys)->toContain('invoice-download');
     expect($invoiceKeys)->toContain('invoice-send');
     expect($invoiceKeys)->toContain('invoice-send-reminder');

--- a/tests/Feature/LegacyTokenRedirectTest.php
+++ b/tests/Feature/LegacyTokenRedirectTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use App\Models\Athlete;
+use App\Models\Donation;
+use App\Models\DonationEvent;
+use App\Models\Donor;
+use App\Models\Partner;
+use App\Models\SportType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('redirects legacy athlete token route to portal without auth side effects', function (): void {
+    $event = DonationEvent::factory()->create();
+    $partner = Partner::factory()->create();
+    $sportType = SportType::query()->create(['name' => 'Laufen']);
+    $athlete = Athlete::factory()->create([
+        'donation_event_id' => $event->id,
+        'partner_id' => $partner->id,
+        'sport_type_id' => $sportType->id,
+        'verified' => false,
+    ]);
+
+    $this->get(route('show-athlete', ['login_token' => $athlete->login_token]))
+        ->assertRedirect(route('portal.dashboard'));
+
+    expect((bool) $athlete->fresh()->verified)->toBeFalse();
+    $this->assertGuest('external');
+});
+
+it('redirects legacy donor token routes to portal without mutation side effects', function (): void {
+    $event = DonationEvent::factory()->create();
+    $partner = Partner::factory()->create();
+    $sportType = SportType::query()->create(['name' => 'Rad']);
+    $athlete = Athlete::factory()->create([
+        'donation_event_id' => $event->id,
+        'partner_id' => $partner->id,
+        'sport_type_id' => $sportType->id,
+        'verified' => true,
+    ]);
+    $donor = Donor::factory()->create();
+
+    $donation = Donation::query()->create([
+        'donor_id' => $donor->id,
+        'athlete_id' => $athlete->id,
+        'amount_per_round' => 5,
+        'amount_min' => 10,
+        'amount_max' => 40,
+        'verified' => false,
+    ]);
+
+    $this->get(route('show-donor', ['login_token' => $donor->login_token]))
+        ->assertRedirect(route('portal.dashboard'));
+
+    $this->get(route('verify-donation', ['login_token' => $donor->login_token, 'donation_id' => $donation->id]))
+        ->assertRedirect(route('portal.dashboard'));
+
+    expect((bool) $donation->fresh()->verified)->toBeFalse();
+    $this->assertGuest('external');
+});

--- a/tests/Feature/Livewire/LoginFormTest.php
+++ b/tests/Feature/Livewire/LoginFormTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use App\Components\LoginForm;
+use App\Models\Athlete;
+use App\Models\DonationEvent;
+use App\Models\Donor;
+use App\Models\ExternalUser;
+use App\Models\Partner;
+use App\Models\SportType;
+use App\Notifications\NewLoginLink;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+it('normalizes email and resolves external user login first', function (): void {
+    Notification::fake();
+
+    $normalizedEmail = 'person@example.com';
+    $inputEmail = '  PERSON@EXAMPLE.COM  ';
+
+    $sportType = SportType::query()->create(['name' => 'Laufen']);
+    $event = DonationEvent::factory()->create();
+    $partner = Partner::factory()->create();
+
+    $athlete = Athlete::factory()->create([
+        'email' => $normalizedEmail,
+        'donation_event_id' => $event->id,
+        'partner_id' => $partner->id,
+        'sport_type_id' => $sportType->id,
+    ]);
+    $donor = Donor::factory()->create([
+        'email' => $normalizedEmail,
+    ]);
+    $externalUser = ExternalUser::factory()->create([
+        'email' => $normalizedEmail,
+        'first_name' => 'Portal',
+    ]);
+
+    Livewire::test(LoginForm::class)
+        ->set('email', $inputEmail)
+        ->call('save');
+
+    Notification::assertSentOnDemand(NewLoginLink::class, function (NewLoginLink $notification, array $channels, object $notifiable) use ($athlete, $donor, $externalUser): bool {
+        expect($notifiable->routes['mail'])->toBe('person@example.com');
+
+        return $notification->first_name === $externalUser->first_name
+            && $notification->athlete_login_token === $athlete->login_token
+            && $notification->donor_login_token === $donor->login_token
+            && $notification->external_user_login_url !== '';
+    });
+});

--- a/tests/Feature/PagesTest.php
+++ b/tests/Feature/PagesTest.php
@@ -181,12 +181,12 @@ test('parameterized routes can be accessed with valid parameters', function () {
         'verified' => true,
     ]);
     $response = $this->get(route('show-athlete', ['login_token' => $athlete->login_token]));
-    $response->assertSuccessful();
+    $response->assertRedirect(route('portal.dashboard'));
 
     // Test donor route
     $donor = Donor::factory()->create();
     $response = $this->get(route('show-donor', ['login_token' => $donor->login_token]));
-    $response->assertSuccessful();
+    $response->assertRedirect(route('portal.dashboard'));
 
 });
 

--- a/tests/Feature/PortalReadSwitchTest.php
+++ b/tests/Feature/PortalReadSwitchTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\Athlete;
+use App\Models\AthleteRegistration;
+use App\Models\Donation;
+use App\Models\DonationEvent;
+use App\Models\Donor;
+use App\Models\ExternalUser;
+use App\Models\Partner;
+use App\Models\SportType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+it('renders merged external user portal data grouped by donation event', function (): void {
+    $sportType = SportType::query()->create(['name' => 'Laufen']);
+
+    $eventA = DonationEvent::factory()->create([
+        'title' => 'Event Alpha',
+        'starts_at' => '2035-09-12 10:00:00',
+    ]);
+    $eventB = DonationEvent::factory()->create([
+        'title' => 'Event Beta',
+        'starts_at' => '2036-09-12 10:00:00',
+    ]);
+
+    $externalUser = ExternalUser::factory()->create([
+        'first_name' => 'Alex',
+        'last_name' => 'Muster',
+    ]);
+
+    $partner = Partner::factory()->create();
+
+    $supporter = ExternalUser::factory()->create([
+        'first_name' => 'Pat',
+        'last_name' => 'Support',
+    ]);
+
+    $athleteRegistration = AthleteRegistration::factory()->create([
+        'external_user_id' => $externalUser->id,
+        'donation_event_id' => $eventA->id,
+        'sport_type_id' => $sportType->id,
+        'rounds_estimated' => 8,
+        'verified' => true,
+    ]);
+
+    Donation::query()->create([
+        'donor_id' => Donor::factory()->create()->id,
+        'athlete_id' => Athlete::factory()->create([
+            'donation_event_id' => $eventA->id,
+            'partner_id' => $partner->id,
+            'sport_type_id' => $sportType->id,
+            'verified' => true,
+        ])->id,
+        'donor_external_user_id' => $supporter->id,
+        'athlete_registration_id' => $athleteRegistration->id,
+        'amount_per_round' => 11,
+        'amount_min' => 20,
+        'amount_max' => 100,
+        'comment' => 'Viel Erfolg',
+        'verified' => true,
+    ]);
+
+    $otherAthlete = ExternalUser::factory()->create([
+        'first_name' => 'Sam',
+        'last_name' => 'Runner',
+    ]);
+    $otherRegistration = AthleteRegistration::factory()->create([
+        'external_user_id' => $otherAthlete->id,
+        'donation_event_id' => $eventB->id,
+        'sport_type_id' => $sportType->id,
+        'rounds_estimated' => 12,
+        'verified' => true,
+    ]);
+
+    Donation::query()->create([
+        'donor_id' => Donor::factory()->create()->id,
+        'athlete_id' => Athlete::factory()->create([
+            'donation_event_id' => $eventB->id,
+            'partner_id' => $partner->id,
+            'sport_type_id' => $sportType->id,
+            'verified' => true,
+        ])->id,
+        'donor_external_user_id' => $externalUser->id,
+        'athlete_registration_id' => $otherRegistration->id,
+        'amount_per_round' => 7,
+        'amount_min' => 15,
+        'amount_max' => 90,
+        'comment' => null,
+        'verified' => false,
+    ]);
+
+    $this->actingAs($externalUser, 'external')
+        ->get(route('portal.dashboard'))
+        ->assertSuccessful()
+        ->assertSeeText('Hallo Alex')
+        ->assertSeeText('Event Alpha')
+        ->assertSeeText('Event Beta')
+        ->assertSeeText('Ich bin Sportler:in')
+        ->assertSeeText('Ich spende')
+        ->assertSeeText($supporter->privacy_name)
+        ->assertSeeText($otherAthlete->privacy_name);
+});


### PR DESCRIPTION
This PR completes the second phase of the external-users refactor by adding the one-time guarded backfill command and switching portal reads to the new `external_users`/`athlete_registrations` graph while preserving rollout safety checks. It reduces migration risk by enforcing strict preflight/parity validation and proving the deployment path in upgrade-lab rehearsal.

## Details

- Adds `hfm:backfill:external-users` with strict preflight checks, `--dry-run`, transactional write mode, and post-write parity validation.
- Switches portal identity/read paths to external users and removes legacy token-auth side effects by redirecting legacy token routes to `/portal`.
- Finalizes PR2 verification items, including full precommit checks and upgrade-lab rehearsal.

## Notes

After deployment, run the backfill command immediately in this order:

```sh
php artisan hfm:backfill:external-users --dry-run
php artisan hfm:backfill:external-users
```

Full end-to-end upgrade rehearsal was executed with upgrade-lab against production database dump (dry-run + write-mode backfill during target pause), and the gate passed.

## Reviewer Setup

In this PR vs `origin/main`, changes were made in backend command flow, routing/views, and test/config updates (including Composer lock updates and Blade template changes). No migrations were added.

You likely need to run:

```sh
composer install
npm run build
php artisan optimize:clear
```

---
**«When there is no desire, all things are at peace.»**
_Laozi_