### PR TITLE
fix: prevent duplicate partner names in factory seeder

### DIFF
--- a/database/factories/PartnerFactory.php
+++ b/database/factories/PartnerFactory.php
@@ -20,7 +20,7 @@ class PartnerFactory extends Factory
     public function definition(): array
     {
         return [
-            'name' => fake()->company(),
+            'name' => fake()->unique()->company(),
             'logo_light_filename' => fake()->slug().'_light.svg',
             'logo_dark_filename' => fake()->slug().'_dark.svg',
             'beneficiary_blurb' => fake()->sentence(12),


### PR DESCRIPTION
The `partners` table has a unique constraint on `name`, but `fake()->company()` can produce duplicates. In CI this caused a `UniqueConstraintViolationException` when two partners named "Weibel" were generated.

Use `fake()->unique()->company()` to guarantee unique names across factory calls.

## Reviewer Setup

In this PR vs `origin/main`, changes were made in database factories. You likely need to run:

```sh
php artisan boost:update
php artisan optimize:clear
```

---
**«Simplicity is the essence of happiness.»**
_Cedric Bledsoe_