### PR TITLE
fix: align previous donors terminology

### DIFF
--- a/resources/views/forms/athlete-registration-wizard.blade.php
+++ b/resources/views/forms/athlete-registration-wizard.blade.php
@@ -233,7 +233,7 @@
             @elseif ($currentStep === 'previous-donors')
                 <div class="space-y-6">
                     <flux:callout icon="megaphone" color="green">
-                        <flux:callout.heading>Frühere Unterstützer:innen aktivieren</flux:callout.heading>
+                        <flux:callout.heading>Frühere Spender:innen informieren</flux:callout.heading>
                         <flux:callout.text>
                             Nach deiner Bestätigung werden frühere Spender:innen informiert, dass du wieder teilnimmst.
                         </flux:callout.text>

--- a/tests/Feature/AthleteRegistrationWizardTest.php
+++ b/tests/Feature/AthleteRegistrationWizardTest.php
@@ -318,7 +318,7 @@ it('stores previous donor notification opt out from the wizard', function (): vo
         ->call('next')
         ->assertSet('currentStep', 'previous-donors')
         ->assertSee('Schritt 2 von 3')
-        ->assertSee('Frühere Unterstützer:innen aktivieren')
+        ->assertSee('Frühere Spender:innen informieren')
         ->set('notify_previous_donors', false)
         ->assertSee('Ohne Hinweis an frühere Spender:innen')
         ->set('privacy_accepted', true)


### PR DESCRIPTION
Aligns athlete registration copy so the previous-donors step consistently refers to earlier donors as `Spender:innen`, matching the explanatory text and test expectation.

## Details

- [athlete-registration-wizard.blade.php](https://github.com/fuermenschen/hfm/blob/fix/donors-naming/resources/views/forms/athlete-registration-wizard.blade.php) - updates the visible callout heading in the previous-donors step
- [AthleteRegistrationWizardTest.php](https://github.com/fuermenschen/hfm/blob/fix/donors-naming/tests/Feature/AthleteRegistrationWizardTest.php) - keeps the wizard assertion aligned with the UI copy

## Reviewer Setup

In this PR vs `origin/main`, changes were made in Blade UI copy and feature test expectations. You likely need to run:

~~~sh
npm run build
php artisan boost:update
php artisan optimize:clear
~~~

---
**«I begin to speak only when I am certain what I will say is not better left unsaid.»**
_Cato the Younger_