### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,9 +125,9 @@ jobs:
               echo "Failed to put application in maintenance mode. Continuing deployment..."
             fi
 
-            echo "Pulling latest changes from the repository..."
-            git reset --hard
-            git pull origin main || { echo "Git pull failed! Exiting."; exit 1; }
+            echo "Fetching latest changes from the repository..."
+            git fetch origin main || { echo "Git fetch failed! Exiting."; exit 1; }
+            git reset --hard origin/main || { echo "Git reset to origin/main failed! Exiting."; exit 1; }
 
             echo "Decrypting environment file..."
             $PHP_BIN artisan env:decrypt --env=production --key=${{ secrets.ENV_PRODUCTION_KEY }} --force --filename=.env || { echo "Environment decryption failed! Exiting."; exit 1; }


### PR DESCRIPTION
Deployment now updates production from the exact remote `main` state instead of doing a local pull. This avoids deploy failures caused by dirty or diverged working trees on the server.

## Details

- [deploy.yml](https://github.com/fuermenschen/hfm/blob/fix/deployment-workflow/.github/workflows/deploy.yml) - replaces `git pull` with `git fetch` plus `git reset --hard origin/main` during deploy

## Reviewer Setup

In this PR vs `origin/main`, changes were made in GitHub Actions deployment workflow. You likely need to run:

```sh
php artisan boost:update
php artisan optimize:clear
```

---
**«Breathing in, I calm body and mind. Breathing out, I smile.»**
_Thich Nhat Hanh_