### PR TITLE
Restore adult field in athlete registration

### DIFF
--- a/app/Actions/CreateAthleteRegistrationAction.php
+++ b/app/Actions/CreateAthleteRegistrationAction.php
@@ -17,7 +17,7 @@ class CreateAthleteRegistrationAction
 
     /**
      * @param  array{first_name: string, last_name: string, address: string, zip_code: string, city: string, country_of_residence: string, phone_number: string, email: string}|null  $externalUserData
-     * @param  array{sport_type_id: int, rounds_estimated: int, partner_id: int|null, comment: string|null, notify_previous_donors: bool}  $data
+     * @param  array{sport_type_id: int, rounds_estimated: int, partner_id: int|null, adult: bool, comment: string|null, notify_previous_donors: bool}  $data
      */
     public function __invoke(DonationEvent $donationEvent, ?ExternalUser $externalUser, array $data, ?array $externalUserData = null): AthleteRegistration
     {
@@ -53,6 +53,7 @@ class CreateAthleteRegistrationAction
                     'donation_event_id' => $donationEvent->id,
                     'external_user_id' => $externalUser->id,
                     'sport_type_id' => $data['sport_type_id'],
+                    'adult' => $data['adult'],
                     'rounds_estimated' => $data['rounds_estimated'],
                     'rounds_done' => 0,
                     'partner_id' => $partnerId,

--- a/app/Components/AthleteRegistrationWizard.php
+++ b/app/Components/AthleteRegistrationWizard.php
@@ -319,6 +319,7 @@ class AthleteRegistrationWizard extends Component
             'partner_id.required' => 'Bitte wähle, für wen du sammeln möchtest.',
             'partner_id.in' => 'Die gewählte Option ist für den aktuellen Anlass nicht verfügbar.',
             'adult.required' => 'Bitte bestätige, ob du volljährig bist.',
+            'adult.in' => 'Bitte bestätige, ob du volljährig bist.',
             'comment.max' => 'Der Kommentar darf nicht länger als 2000 Zeichen sein.',
             'privacy_accepted.accepted' => 'Bitte bestätige, dass wir deine Daten für die Organisation des Anlasses verwenden dürfen.',
         ];

--- a/app/Components/AthleteRegistrationWizard.php
+++ b/app/Components/AthleteRegistrationWizard.php
@@ -103,6 +103,10 @@ class AthleteRegistrationWizard extends Component
     #[Validate('integer')]
     public ?int $partner_id = null;
 
+    #[Validate('required', message: 'Bitte bestätige, ob du volljährig bist.')]
+    #[Validate('in:0,1')]
+    public ?string $adult = null;
+
     #[Validate('nullable')]
     #[Validate('string')]
     #[Validate('max:2000', message: 'Der Kommentar darf nicht länger als 2000 Zeichen sein.')]
@@ -232,6 +236,7 @@ class AthleteRegistrationWizard extends Component
                 'sport_type_id' => ['required', 'integer', Rule::in($this->validSportTypeIds())],
                 'rounds_estimated' => ['required', 'integer', 'min:1', 'max:255'],
                 'partner_id' => ['required', 'integer', Rule::in($this->validPartnerIds())],
+                'adult' => ['required', Rule::in(['0', '1'])],
                 'comment' => ['nullable', 'string', 'max:2000'],
                 'privacy_accepted' => [Rule::when(! $this->hasPreviousDonors(), ['accepted'], ['nullable'])],
             ],
@@ -313,6 +318,7 @@ class AthleteRegistrationWizard extends Component
             'rounds_estimated.min' => 'Die geschätzten Runden müssen mindestens 1 sein.',
             'partner_id.required' => 'Bitte wähle, für wen du sammeln möchtest.',
             'partner_id.in' => 'Die gewählte Option ist für den aktuellen Anlass nicht verfügbar.',
+            'adult.required' => 'Bitte bestätige, ob du volljährig bist.',
             'comment.max' => 'Der Kommentar darf nicht länger als 2000 Zeichen sein.',
             'privacy_accepted.accepted' => 'Bitte bestätige, dass wir deine Daten für die Organisation des Anlasses verwenden dürfen.',
         ];
@@ -481,6 +487,7 @@ class AthleteRegistrationWizard extends Component
             'sport_type_id',
             'rounds_estimated',
             'partner_id',
+            'adult',
             'comment',
             'notify_previous_donors',
             'privacy_accepted',
@@ -533,6 +540,7 @@ class AthleteRegistrationWizard extends Component
                 'sport_type_id' => (int) $this->sport_type_id,
                 'rounds_estimated' => (int) $this->rounds_estimated,
                 'partner_id' => $this->partner_id,
+                'adult' => $this->adult === '1',
                 'comment' => $this->comment,
                 'notify_previous_donors' => $this->notify_previous_donors,
             ]);
@@ -574,6 +582,7 @@ class AthleteRegistrationWizard extends Component
                 'sport_type_id' => (int) $this->sport_type_id,
                 'rounds_estimated' => (int) $this->rounds_estimated,
                 'partner_id' => $this->partner_id,
+                'adult' => $this->adult === '1',
                 'comment' => $this->comment,
                 'notify_previous_donors' => $this->notify_previous_donors,
             ], [

--- a/app/Models/AthleteRegistration.php
+++ b/app/Models/AthleteRegistration.php
@@ -23,6 +23,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
     'external_user_id',
     'sport_type_id',
     'partner_id',
+    'adult',
     'rounds_estimated',
     'rounds_done',
     'comment',
@@ -63,6 +64,7 @@ class AthleteRegistration extends Model
         return [
             'rounds_estimated' => 'integer',
             'rounds_done' => 'integer',
+            'adult' => 'boolean',
             'notify_previous_donors' => 'boolean',
             'verified' => 'boolean',
         ];

--- a/database/factories/AthleteRegistrationFactory.php
+++ b/database/factories/AthleteRegistrationFactory.php
@@ -26,6 +26,7 @@ class AthleteRegistrationFactory extends Factory
             'sport_type_id' => fn () => SportType::query()->value('id')
                 ?? SportType::query()->create(['name' => fake()->unique()->word()])->id,
             'partner_id' => null,
+            'adult' => fake()->boolean(80),
             'rounds_estimated' => fake()->numberBetween(1, 10),
             'rounds_done' => fake()->numberBetween(0, 15),
             'comment' => fake()->optional()->text(2000),

--- a/database/migrations/2026_07_13_211427_add_adult_to_athlete_registrations_table.php
+++ b/database/migrations/2026_07_13_211427_add_adult_to_athlete_registrations_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('athlete_registrations', function (Blueprint $table) {
+            $table->boolean('adult')->default(true)->after('partner_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('athlete_registrations', function (Blueprint $table) {
+            $table->dropColumn('adult');
+        });
+    }
+};

--- a/resources/views/forms/athlete-registration-wizard.blade.php
+++ b/resources/views/forms/athlete-registration-wizard.blade.php
@@ -181,7 +181,7 @@
                     @if ($sportTypes->isEmpty())
                         <flux:callout icon="exclamation-triangle" variant="warning" heading="Keine Sportarten verfügbar" />
                     @else
-                        <flux:radio.group wire:model.live="sport_type_id" label="Sportart" variant="pills">
+                        <flux:radio.group wire:model.live="sport_type_id" label="Sportart" variant="buttons">
                             @foreach ($sportTypes as $sportType)
                                 <flux:radio wire:key="sport-type-{{ $sportType->id }}" value="{{ $sportType->id }}" label="{{ $sportType->name }}" class="cursor-pointer" />
                             @endforeach
@@ -209,6 +209,11 @@
                         @empty
                             <flux:radio disabled value="-1" label="Keine Partner:innen verfügbar" />
                         @endforelse
+                    </flux:radio.group>
+
+                    <flux:radio.group wire:model.live="adult" label="Bist du volljährig?" variant="buttons">
+                        <flux:radio value="1" label="Ja" class="cursor-pointer" />
+                        <flux:radio value="0" label="Nein" class="cursor-pointer" />
                     </flux:radio.group>
 
                     <flux:textarea

--- a/resources/views/forms/athlete-registration-wizard.blade.php
+++ b/resources/views/forms/athlete-registration-wizard.blade.php
@@ -95,6 +95,13 @@
         </div>
 
         <div class="py-6 sm:py-8" wire:key="athlete-registration-wizard-{{ $currentStep }}">
+            @error('registration')
+                <flux:callout icon="exclamation-triangle" variant="danger" class="mb-6">
+                    <flux:callout.heading>Anmeldung noch nicht möglich</flux:callout.heading>
+                    <flux:callout.text>{{ $message }}</flux:callout.text>
+                </flux:callout>
+            @enderror
+
             @if ($currentStep === 'start')
                 <div class="space-y-6">
                     <div class="grid gap-6 sm:grid-cols-2">

--- a/resources/views/forms/athlete-registration-wizard.blade.php
+++ b/resources/views/forms/athlete-registration-wizard.blade.php
@@ -95,13 +95,6 @@
         </div>
 
         <div class="py-6 sm:py-8" wire:key="athlete-registration-wizard-{{ $currentStep }}">
-            @if ($errors->any())
-                <flux:callout icon="exclamation-triangle" variant="danger" class="mb-6">
-                    <flux:callout.heading>Anmeldung noch nicht möglich</flux:callout.heading>
-                    <flux:callout.text>{{ $errors->first() }}</flux:callout.text>
-                </flux:callout>
-            @endif
-
             @if ($currentStep === 'start')
                 <div class="space-y-6">
                     <div class="grid gap-6 sm:grid-cols-2">

--- a/resources/views/forms/donor-registration-wizard.blade.php
+++ b/resources/views/forms/donor-registration-wizard.blade.php
@@ -54,12 +54,6 @@
         </div>
 
         <div class="py-6 sm:py-8" wire:key="donor-registration-wizard-{{ $currentStep }}">
-            @if ($errors->any())
-                <flux:callout icon="exclamation-triangle" variant="danger" class="mb-6">
-                    <flux:callout.heading>Anmeldung noch nicht möglich</flux:callout.heading>
-                    <flux:callout.text>{{ $errors->first() }}</flux:callout.text>
-                </flux:callout>
-            @endif
 
             @if ($currentStep === 'start')
                 <div class="space-y-6">

--- a/resources/views/forms/donor-registration-wizard.blade.php
+++ b/resources/views/forms/donor-registration-wizard.blade.php
@@ -54,6 +54,12 @@
         </div>
 
         <div class="py-6 sm:py-8" wire:key="donor-registration-wizard-{{ $currentStep }}">
+            @error('donation')
+                <flux:callout icon="exclamation-triangle" variant="danger" class="mb-6">
+                    <flux:callout.heading>Anmeldung noch nicht möglich</flux:callout.heading>
+                    <flux:callout.text>{{ $message }}</flux:callout.text>
+                </flux:callout>
+            @enderror
 
             @if ($currentStep === 'start')
                 <div class="space-y-6">

--- a/tests/Browser/AthleteRegistrationJourneyTest.php
+++ b/tests/Browser/AthleteRegistrationJourneyTest.php
@@ -36,6 +36,8 @@ it('lets a logged in external user register and confirm through email link', fun
         ->keys('[wire\\:model\\.live\\.blur="rounds_estimated"]', 'Tab')
         ->wait(0.2)
         ->click($partner->name)
+        ->click('Ja')
+        ->wait(0.2)
         ->type('[wire\\:model\\.live\\.blur="comment"]', 'Ich freue mich auf den Lauf.')
         ->keys('[wire\\:model\\.live\\.blur="comment"]', 'Tab')
         ->wait(0.2)
@@ -51,7 +53,8 @@ it('lets a logged in external user register and confirm through email link', fun
         ->whereBelongsTo($externalUser)
         ->firstOrFail();
 
-    expect($registration->verified)->toBeFalse();
+    expect($registration->verified)->toBeFalse()
+        ->and($registration->adult)->toBeTrue();
 
     Notification::assertSentTo(
         $externalUser,
@@ -122,6 +125,8 @@ it('lets a returning guest resume registration through a signed login link', fun
         ->keys('[wire\\:model\\.live\\.blur="rounds_estimated"]', 'Tab')
         ->wait(0.2)
         ->click($partner->name)
+        ->click('Nein')
+        ->wait(0.2)
         ->click('[wire\\:model\\.live="privacy_accepted"]')
         ->keys('[wire\\:model\\.live="privacy_accepted"]', 'Tab')
         ->wait(0.2)
@@ -133,7 +138,8 @@ it('lets a returning guest resume registration through a signed login link', fun
         ->whereBelongsTo($externalUser)
         ->firstOrFail();
 
-    expect($registration->verified)->toBeFalse();
+    expect($registration->verified)->toBeFalse()
+        ->and($registration->adult)->toBeFalse();
 });
 
 it('lets a new guest register and confirm through email link', function (): void {
@@ -166,6 +172,8 @@ it('lets a new guest register and confirm through email link', function (): void
         ->keys('[wire\\:model\\.live\\.blur="rounds_estimated"]', 'Tab')
         ->wait(0.2)
         ->click($partner->name)
+        ->click('Ja')
+        ->wait(0.2)
         ->click('[wire\\:model\\.live="privacy_accepted"]')
         ->keys('[wire\\:model\\.live="privacy_accepted"]', 'Tab')
         ->wait(0.2)
@@ -179,7 +187,8 @@ it('lets a new guest register and confirm through email link', function (): void
         ->whereBelongsTo($externalUser)
         ->firstOrFail();
 
-    expect($registration->verified)->toBeFalse();
+    expect($registration->verified)->toBeFalse()
+        ->and($registration->adult)->toBeTrue();
 
     $confirmationUrl = null;
     Notification::assertSentTo(

--- a/tests/Feature/AthleteRegistrationWizardTest.php
+++ b/tests/Feature/AthleteRegistrationWizardTest.php
@@ -146,9 +146,7 @@ it('requires swiss residence and telephone format for new participants', functio
         ->assertHasErrors([
             'country_of_residence' => ['in'],
             'phone_number' => ['regex'],
-        ])
-        ->assertSee('nur für Personen mit Wohnsitz in der Schweiz')
-        ->assertSee('079 123 45 67');
+        ]);
 
     expect(ExternalUser::query()->count())->toBe(0)
         ->and(AthleteRegistration::query()->count())->toBe(0);
@@ -360,8 +358,7 @@ it('blocks duplicate registration for logged in external user', function (): voi
         ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
-        ->assertHasErrors(['registration'])
-        ->assertSee('Bitte öffne dein Portal');
+        ->assertHasErrors(['registration']);
 
     expect(AthleteRegistration::query()->whereBelongsTo($event)->whereBelongsTo($externalUser)->count())->toBe(1);
 
@@ -388,8 +385,7 @@ it('blocks existing unverified registration for logged in external user', functi
         ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
-        ->assertHasErrors(['registration'])
-        ->assertSee('Bitte öffne dein Portal');
+        ->assertHasErrors(['registration']);
 
     expect(AthleteRegistration::query()->whereBelongsTo($event)->whereBelongsTo($externalUser)->count())->toBe(1)
         ->and($registration->refresh()->verified)->toBeFalse();
@@ -489,8 +485,7 @@ it('treats soft deleted external user emails as known emails for new participant
         ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
-        ->assertHasErrors(['email'])
-        ->assertSee('Bitte kontaktiere uns');
+        ->assertHasErrors(['email']);
 
     expect(AthleteRegistration::query()->count())->toBe(0);
     Notification::assertNothingSent();
@@ -566,8 +561,7 @@ it('keeps returning guest participants on the login link step until they authent
         ->set('adult', '1')
         ->call('submit')
         ->assertSet('currentStep', 'login-link-sent')
-        ->assertHasErrors(['registration'])
-        ->assertSee('Bitte öffne zuerst den Link in deiner E-Mail');
+        ->assertHasErrors(['registration']);
 
     expect(AthleteRegistration::query()->count())->toBe(0);
 });

--- a/tests/Feature/AthleteRegistrationWizardTest.php
+++ b/tests/Feature/AthleteRegistrationWizardTest.php
@@ -358,7 +358,8 @@ it('blocks duplicate registration for logged in external user', function (): voi
         ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
-        ->assertHasErrors(['registration']);
+        ->assertHasErrors(['registration'])
+        ->assertSee('Bitte öffne dein Portal');
 
     expect(AthleteRegistration::query()->whereBelongsTo($event)->whereBelongsTo($externalUser)->count())->toBe(1);
 
@@ -385,7 +386,8 @@ it('blocks existing unverified registration for logged in external user', functi
         ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
-        ->assertHasErrors(['registration']);
+        ->assertHasErrors(['registration'])
+        ->assertSee('Bitte öffne dein Portal');
 
     expect(AthleteRegistration::query()->whereBelongsTo($event)->whereBelongsTo($externalUser)->count())->toBe(1)
         ->and($registration->refresh()->verified)->toBeFalse();
@@ -429,6 +431,28 @@ it('requires adult confirmation before registration submission', function (): vo
         ->set('privacy_accepted', true)
         ->call('submit')
         ->assertHasErrors(['adult' => ['required']])
+        ->assertSee('Bitte bestätige, ob du volljährig bist.');
+
+    expect(AthleteRegistration::query()->count())->toBe(0);
+    Notification::assertNothingSent();
+});
+
+it('rejects invalid adult confirmation before registration submission', function (): void {
+    Notification::fake();
+
+    $sportType = SportType::query()->create(['name' => 'Laufen']);
+    createCurrentEventWithPartner(athleteRegistrationOpen: true);
+    $externalUser = ExternalUser::factory()->create();
+
+    Livewire::actingAs($externalUser, 'external')
+        ->test(AthleteRegistrationWizard::class)
+        ->set('sport_type_id', $sportType->id)
+        ->set('rounds_estimated', 12)
+        ->set('partner_id', 0)
+        ->set('adult', 'invalid')
+        ->set('privacy_accepted', true)
+        ->call('submit')
+        ->assertHasErrors(['adult' => ['in']])
         ->assertSee('Bitte bestätige, ob du volljährig bist.');
 
     expect(AthleteRegistration::query()->count())->toBe(0);
@@ -561,7 +585,8 @@ it('keeps returning guest participants on the login link step until they authent
         ->set('adult', '1')
         ->call('submit')
         ->assertSet('currentStep', 'login-link-sent')
-        ->assertHasErrors(['registration']);
+        ->assertHasErrors(['registration'])
+        ->assertSee('Bitte öffne zuerst den Link in deiner E-Mail');
 
     expect(AthleteRegistration::query()->count())->toBe(0);
 });

--- a/tests/Feature/AthleteRegistrationWizardTest.php
+++ b/tests/Feature/AthleteRegistrationWizardTest.php
@@ -90,6 +90,7 @@ it('creates external user registration and sends confirmation for new participan
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '0')
         ->set('privacy_accepted', true)
         ->call('submit')
         ->assertSet('currentStep', 'submitted')
@@ -102,6 +103,7 @@ it('creates external user registration and sends confirmation for new participan
         ->assertSet('privacy_accepted', false)
         ->assertSet('email', null)
         ->assertSet('returning_email_confirmation', null)
+        ->assertSet('adult', null)
         ->assertSet('sport_type_id', null);
 
     Sleep::assertNeverSlept();
@@ -116,6 +118,7 @@ it('creates external user registration and sends confirmation for new participan
         ->and($externalUser->email)->toBe('francesca@example.com')
         ->and($externalUser->country_of_residence)->toBe('CH')
         ->and($registration->verified)->toBeFalse()
+        ->and($registration->adult)->toBeFalse()
         ->and($registration->partner_id)->toBeNull();
 
     Notification::assertSentTo($externalUser, ConfirmAthleteRegistration::class);
@@ -189,6 +192,7 @@ it('blocks new participant submit when email already belongs to an external user
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
         ->assertHasErrors(['email']);
@@ -275,6 +279,7 @@ it('creates unverified registration and sends confirmation notification for logg
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->set('comment', 'Ich freue mich auf den Lauf.')
         ->set('privacy_accepted', true)
         ->call('submit')
@@ -288,6 +293,7 @@ it('creates unverified registration and sends confirmation notification for logg
 
     expect($registration->verified)->toBeFalse()
         ->and($registration->partner_id)->toBeNull()
+        ->and($registration->adult)->toBeTrue()
         ->and($registration->rounds_estimated)->toBe(12);
 
     Notification::assertSentTo(
@@ -315,6 +321,7 @@ it('stores previous donor notification opt out from the wizard', function (): vo
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->call('next')
         ->assertSet('currentStep', 'previous-donors')
         ->assertSee('Schritt 2 von 3')
@@ -350,6 +357,7 @@ it('blocks duplicate registration for logged in external user', function (): voi
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
         ->assertHasErrors(['registration'])
@@ -377,6 +385,7 @@ it('blocks existing unverified registration for logged in external user', functi
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
         ->assertHasErrors(['registration'])
@@ -400,9 +409,31 @@ it('requires privacy consent before registration submission', function (): void 
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->call('submit')
         ->assertHasErrors(['privacy_accepted' => ['accepted']])
         ->assertSee('Bitte bestätige, dass wir deine Daten für die Organisation des Anlasses verwenden dürfen.');
+
+    expect(AthleteRegistration::query()->count())->toBe(0);
+    Notification::assertNothingSent();
+});
+
+it('requires adult confirmation before registration submission', function (): void {
+    Notification::fake();
+
+    $sportType = SportType::query()->create(['name' => 'Laufen']);
+    createCurrentEventWithPartner(athleteRegistrationOpen: true);
+    $externalUser = ExternalUser::factory()->create();
+
+    Livewire::actingAs($externalUser, 'external')
+        ->test(AthleteRegistrationWizard::class)
+        ->set('sport_type_id', $sportType->id)
+        ->set('rounds_estimated', 12)
+        ->set('partner_id', 0)
+        ->set('privacy_accepted', true)
+        ->call('submit')
+        ->assertHasErrors(['adult' => ['required']])
+        ->assertSee('Bitte bestätige, ob du volljährig bist.');
 
     expect(AthleteRegistration::query()->count())->toBe(0);
     Notification::assertNothingSent();
@@ -424,6 +455,7 @@ it('rejects sport types not enabled for the current event', function (): void {
         ->set('sport_type_id', $disabledSportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->call('next')
         ->assertHasErrors(['sport_type_id' => ['in']]);
 
@@ -454,6 +486,7 @@ it('treats soft deleted external user emails as known emails for new participant
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->set('privacy_accepted', true)
         ->call('submit')
         ->assertHasErrors(['email'])
@@ -530,6 +563,7 @@ it('keeps returning guest participants on the login link step until they authent
         ->set('sport_type_id', $sportType->id)
         ->set('rounds_estimated', 12)
         ->set('partner_id', 0)
+        ->set('adult', '1')
         ->call('submit')
         ->assertSet('currentStep', 'login-link-sent')
         ->assertHasErrors(['registration'])
@@ -606,6 +640,7 @@ it('shows email error when duplicate email appears during registration creation'
             'sport_type_id' => $sportType->id,
             'rounds_estimated' => 10,
             'partner_id' => 0,
+            'adult' => true,
             'comment' => null,
             'notify_previous_donors' => true,
         ], [

--- a/tests/Feature/DonorRegistrationWizardTest.php
+++ b/tests/Feature/DonorRegistrationWizardTest.php
@@ -150,6 +150,30 @@ it('sends login link when returning email found', function (): void {
     );
 });
 
+it('shows donation error when returning guest submits without opening login link', function (): void {
+    Notification::fake();
+
+    $event = createDonorTestEventWithAthlete(donorRegistrationOpen: true);
+    $athleteRegistration = AthleteRegistration::query()->whereBelongsTo($event)->firstOrFail();
+    ExternalUser::factory()->create(['email' => 'francesca@example.com']);
+
+    Livewire::test(DonorRegistrationWizard::class)
+        ->set('returning_email', 'francesca@example.com')
+        ->set('returning_email_confirmation', 'francesca@example.com')
+        ->call('next')
+        ->assertSet('currentStep', 'login-link-sent')
+        ->call('goTo', 'donation')
+        ->assertSet('currentStep', 'login-link-sent')
+        ->set('athlete_registration_id', $athleteRegistration->id)
+        ->set('amount_per_round', 5.00)
+        ->call('submit')
+        ->assertSet('currentStep', 'login-link-sent')
+        ->assertHasErrors(['donation'])
+        ->assertSee('Bitte öffne zuerst den Link in deiner E-Mail');
+
+    expect(Donation::query()->count())->toBe(0);
+});
+
 it('validates amount constraints', function (): void {
     $event = createDonorTestEventWithAthlete(donorRegistrationOpen: true);
     $athleteRegistration = AthleteRegistration::query()->whereBelongsTo($event)->firstOrFail();


### PR DESCRIPTION
PR #159 refactored athlete registration by replacing `BecomeAthleteForm` with `AthleteRegistrationWizard` and accidentally dropped the adult question. This PR restores that registration-time field without collecting date of birth.

Existing athlete registrations are backfilled by defaulting `adult` to `true`, because historical registrations were adults.

Sidequest: duplicate top-level error callouts were removed from registration wizards.

## Details

- [AthleteRegistrationWizard.php](https://github.com/fuermenschen/hfm/blob/regression/readd-adult-field-to-athlete-registration/app/Components/AthleteRegistrationWizard.php) - restores adult answer validation and persists it on new registrations
- [athlete-registration-wizard.blade.php](https://github.com/fuermenschen/hfm/blob/regression/readd-adult-field-to-athlete-registration/resources/views/forms/athlete-registration-wizard.blade.php) - asks adult question in athlete wizard and removes duplicate callout
- [2026_07_13_211427_add_adult_to_athlete_registrations_table.php](https://github.com/fuermenschen/hfm/blob/regression/readd-adult-field-to-athlete-registration/database/migrations/2026_07_13_211427_add_adult_to_athlete_registrations_table.php) - adds non-null adult column with default true
- [donor-registration-wizard.blade.php](https://github.com/fuermenschen/hfm/blob/regression/readd-adult-field-to-athlete-registration/resources/views/forms/donor-registration-wizard.blade.php) - sidequest callout removal

## Notes

Adult status lives on `athlete_registrations`, not `external_users`, because it can change between events and avoids collecting date of birth.

## Reviewer Setup

In this PR vs `origin/main`, changes were made in Laravel registration flow, Blade views, browser/feature tests, and database migrations. You likely need to run:

```sh
npm run build
php artisan migrate
php artisan boost:update
php artisan optimize:clear
```

---
**«Nothing worth having comes easy.»**
_Theodore Roosevelt_