### PR TITLE
Add donation event settings management

### DIFF
--- a/.github/skills/laravel-best-practices/SKILL.md
+++ b/.github/skills/laravel-best-practices/SKILL.md
@@ -8,183 +8,52 @@ metadata:
 
 # Laravel Best Practices
 
-Best practices for Laravel, prioritized by impact. Each rule teaches what to do and why. For exact API syntax, verify with `search-docs`.
+Best practices for Laravel, organized as an index of rule files. Each rule file teaches what to do and why. For exact API syntax, verify with `search-docs`.
 
 ## Consistency First
 
-Before applying any rule, check what the application already does. Laravel offers multiple valid approaches — the best choice is the one the codebase already uses, even if another pattern would be theoretically better. Inconsistency is worse than a suboptimal pattern.
+Before applying any rule, check what the application already does. Laravel offers multiple valid approaches, and the best choice is the one the codebase already uses, even if another pattern would be theoretically better. Inconsistency is worse than a suboptimal pattern.
 
-Check sibling files, related controllers, models, or tests for established patterns. If one exists, follow it — don't introduce a second way. These rules are defaults for when no pattern exists yet, not overrides.
-
-## Quick Reference
-
-### 1. Database Performance → `rules/db-performance.md`
-
-- Eager load with `with()` to prevent N+1 queries
-- Enable `Model::preventLazyLoading()` in development
-- Select only needed columns, avoid `SELECT *`
-- `chunk()` / `chunkById()` for large datasets
-- Index columns used in `WHERE`, `ORDER BY`, `JOIN`
-- `withCount()` instead of loading relations to count
-- `cursor()` for memory-efficient read-only iteration
-- Never query in Blade templates
-
-### 2. Advanced Query Patterns → `rules/advanced-queries.md`
-
-- `addSelect()` subqueries over eager-loading entire has-many for a single value
-- Dynamic relationships via subquery FK + `belongsTo`
-- Conditional aggregates (`CASE WHEN` in `selectRaw`) over multiple count queries
-- `setRelation()` to prevent circular N+1 queries
-- `whereIn` + `pluck()` over `whereHas` for better index usage
-- Two simple queries can beat one complex query
-- Compound indexes matching `orderBy` column order
-- Correlated subqueries in `orderBy` for has-many sorting (avoid joins)
-
-### 3. Security → `rules/security.md`
-
-- Define `$fillable` or `$guarded` on every model, authorize every action via policies or gates
-- No raw SQL with user input — use Eloquent or query builder
-- `{{ }}` for output escaping, `@csrf` on all POST/PUT/DELETE forms, `throttle` on auth and API routes
-- Validate MIME type, extension, and size for file uploads
-- Never commit `.env`, use `config()` for secrets, `encrypted` cast for sensitive DB fields
-
-### 4. Caching → `rules/caching.md`
-
-- `Cache::remember()` over manual get/put
-- `Cache::flexible()` for stale-while-revalidate on high-traffic data
-- `Cache::memo()` to avoid redundant cache hits within a request
-- Cache tags to invalidate related groups
-- `Cache::add()` for atomic conditional writes
-- `once()` to memoize per-request or per-object lifetime
-- `Cache::lock()` / `lockForUpdate()` for race conditions
-- Failover cache stores in production
-
-### 5. Eloquent Patterns → `rules/eloquent.md`
-
-- Correct relationship types with return type hints
-- Local scopes for reusable query constraints
-- Global scopes sparingly — document their existence
-- Attribute casts in the `casts()` method
-- Cast date columns, use Carbon instances in templates
-- `whereBelongsTo($model)` for cleaner queries
-- Never hardcode table names — use `(new Model)->getTable()` or Eloquent queries
-
-### 6. Validation & Forms → `rules/validation.md`
-
-- Form Request classes, not inline validation
-- Array notation `['required', 'email']` for new code; follow existing convention
-- `$request->validated()` only — never `$request->all()`
-- `Rule::when()` for conditional validation
-- `after()` instead of `withValidator()`
-
-### 7. Configuration → `rules/config.md`
-
-- `env()` only inside config files
-- `App::environment()` or `app()->isProduction()`
-- Config, lang files, and constants over hardcoded text
-
-### 8. Testing Patterns → `rules/testing.md`
-
-- `LazilyRefreshDatabase` over `RefreshDatabase` for speed
-- `assertModelExists()` over raw `assertDatabaseHas()`
-- Factory states and sequences over manual overrides
-- Use fakes (`Event::fake()`, `Exceptions::fake()`, etc.) — but always after factory setup, not before
-- `recycle()` to share relationship instances across factories
-
-### 9. Queue & Job Patterns → `rules/queue-jobs.md`
-
-- `retry_after` must exceed job `timeout`; use exponential backoff `[1, 5, 10]`
-- `ShouldBeUnique` to prevent duplicates; `ShouldBeUniqueUntilProcessing` for early lock release
-- Always implement `failed()`; with `retryUntil()`, set `$tries = 0`
-- `RateLimited` middleware for external API calls; `Bus::batch()` for related jobs
-- Horizon for complex multi-queue scenarios
-
-### 10. Routing & Controllers → `rules/routing.md`
-
-- Implicit route model binding
-- Scoped bindings for nested resources
-- `Route::resource()` or `apiResource()`
-- Methods under 10 lines — extract to actions/services
-- Type-hint Form Requests for auto-validation
-
-### 11. HTTP Client → `rules/http-client.md`
-
-- Explicit `timeout` and `connectTimeout` on every request
-- `retry()` with exponential backoff for external APIs
-- Check response status or use `throw()`
-- `Http::pool()` for concurrent independent requests
-- `Http::fake()` and `preventStrayRequests()` in tests
-
-### 12. Events, Notifications & Mail → `rules/events-notifications.md`, `rules/mail.md`
-
-- Event discovery over manual registration; `event:cache` in production
-- `ShouldDispatchAfterCommit` / `afterCommit()` inside transactions
-- Queue notifications and mailables with `ShouldQueue`
-- On-demand notifications for non-user recipients
-- `HasLocalePreference` on notifiable models
-- `assertQueued()` not `assertSent()` for queued mailables
-- Markdown mailables for transactional emails
-
-### 13. Error Handling → `rules/error-handling.md`
-
-- `report()`/`render()` on exception classes or in `bootstrap/app.php` — follow existing pattern
-- `ShouldntReport` for exceptions that should never log
-- Throttle high-volume exceptions to protect log sinks
-- `dontReportDuplicates()` for multi-catch scenarios
-- Force JSON rendering for API routes
-- Structured context via `context()` on exception classes
-
-### 14. Task Scheduling → `rules/scheduling.md`
-
-- `withoutOverlapping()` on variable-duration tasks
-- `onOneServer()` on multi-server deployments
-- `runInBackground()` for concurrent long tasks
-- `environments()` to restrict to appropriate environments
-- `takeUntilTimeout()` for time-bounded processing
-- Schedule groups for shared configuration
-
-### 15. Architecture → `rules/architecture.md`
-
-- Single-purpose Action classes; dependency injection over `app()` helper
-- Prefer official Laravel packages and follow conventions, don't override defaults
-- Default to `ORDER BY id DESC` or `created_at DESC`; `mb_*` for UTF-8 safety
-- `defer()` for post-response work; `Context` for request-scoped data; `Concurrency::run()` for parallel execution
-
-### 16. Migrations → `rules/migrations.md`
-
-- Generate migrations with `php artisan make:migration`
-- `constrained()` for foreign keys
-- Never modify migrations that have run in production
-- Add indexes in the migration, not as an afterthought
-- Mirror column defaults in model `$attributes`
-- Reversible `down()` by default; forward-fix migrations for intentionally irreversible changes
-- One concern per migration — never mix DDL and DML
-
-### 17. Collections → `rules/collections.md`
-
-- Higher-order messages for simple collection operations
-- `cursor()` vs. `lazy()` — choose based on relationship needs
-- `lazyById()` when updating records while iterating
-- `toQuery()` for bulk operations on collections
-
-### 18. Blade & Views → `rules/blade-views.md`
-
-- `$attributes->merge()` in component templates
-- Blade components over `@include`; `@pushOnce` for per-component scripts
-- View Composers for shared view data
-- `@aware` for deeply nested component props
-
-### 19. Conventions & Style → `rules/style.md`
-
-- Follow Laravel naming conventions for all entities
-- Prefer Laravel helpers (`Str`, `Arr`, `Number`, `Uri`, `Str::of()`, `$request->string()`) over raw PHP functions
-- No JS/CSS in Blade, no HTML in PHP classes
-- Code should be readable; comments only for config files
+Check sibling files, related controllers, models, or tests for established patterns. If one exists, follow it. Don't introduce a second way. These rules are defaults for when no pattern exists yet, not overrides.
 
 ## How to Apply
 
-Always use a sub-agent to read rule files and explore this skill's content.
+1. Check the changed files, nearby code, project configuration, and relevant tests for established patterns. Deviate only for a correctness or security defect, and call the deviation out.
+2. Map every affected concern to the rule index below. Read each mapped rule file before editing. Skip unrelated rule files.
+3. Make the smallest coherent change. Keep the application's architecture and naming instead of introducing a second pattern for the same job.
+4. Verify version-sensitive Laravel APIs for the installed version with `search-docs`, or inspect the installed framework when it is unavailable.
+5. Run the narrowest relevant tests first, then the project's formatting and static-analysis checks when the change warrants them.
+6. Re-read the diff against every mapped rule before finishing.
 
-1. Identify the file type and select relevant sections (e.g., migration → §16, controller → §1, §3, §5, §6, §10)
-2. Check sibling files for existing patterns — follow those first per Consistency First
-3. Verify API syntax with `search-docs` for the installed Laravel version
+## Rule Index
+
+Cross-cutting changes often need more than one rule file.
+
+| Concern | Read |
+| --- | --- |
+| Query count, eager loading, indexes, large datasets | [`rules/db-performance.md`](rules/db-performance.md) |
+| Subqueries, aggregates, complex ordering and query plans | [`rules/advanced-queries.md`](rules/advanced-queries.md) |
+| Models, relationships, scopes, casts | [`rules/eloquent.md`](rules/eloquent.md) |
+| Authentication, authorization, input safety, secrets, uploads | [`rules/security.md`](rules/security.md) |
+| Form Requests and validation rules | [`rules/validation.md`](rules/validation.md) |
+| Controllers, route binding, resources, middleware | [`rules/routing.md`](rules/routing.md) |
+| Schema changes, columns, foreign keys, indexes | [`rules/migrations.md`](rules/migrations.md) |
+| Jobs, retries, uniqueness, batches, Horizon | [`rules/queue-jobs.md`](rules/queue-jobs.md) |
+| Cache lifetime, invalidation, locks, memoization | [`rules/caching.md`](rules/caching.md) |
+| Outbound requests, retries, timeouts, fakes | [`rules/http-client.md`](rules/http-client.md) |
+| Exceptions, reporting, rendering, log context | [`rules/error-handling.md`](rules/error-handling.md) |
+| Events and notifications | [`rules/events-notifications.md`](rules/events-notifications.md) |
+| Mailables and mail assertions | [`rules/mail.md`](rules/mail.md) |
+| Scheduled tasks and overlap protection | [`rules/scheduling.md`](rules/scheduling.md) |
+| Collections, lazy iteration, bulk operations | [`rules/collections.md`](rules/collections.md) |
+| Blade components, attributes, composers | [`rules/blade-views.md`](rules/blade-views.md) |
+| Environment values and application configuration | [`rules/config.md`](rules/config.md) |
+| Pest/PHPUnit patterns, factories, fakes | [`rules/testing.md`](rules/testing.md) |
+| Naming, helpers, file boundaries, PHP style | [`rules/style.md`](rules/style.md) |
+| Actions, services, dependencies, application structure | [`rules/architecture.md`](rules/architecture.md) |
+
+## Decision Rules
+
+- Prefer framework features and existing application abstractions over new helpers or dependencies.
+- Avoid speculative abstractions. Extract code when it creates a clear domain boundary, removes meaningful duplication, or makes behavior independently testable.
+- Keep database access out of Blade views and prevent hidden N+1 queries across controllers, resources, jobs, and serialization.

--- a/.github/skills/laravel-best-practices/rules/style.md
+++ b/.github/skills/laravel-best-practices/rules/style.md
@@ -44,7 +44,7 @@ Strings — use `Str` and fluent `Str::of()` over raw PHP:
 // Incorrect
 $slug = strtolower(str_replace(' ', '-', $title));
 $short = substr($text, 0, 100) . '...';
-$class = substr(strrchr('App\Models\User', '\'), 1);
+$class = substr(strrchr('App\Models\User', '\\'), 1);
 
 // Correct
 $slug = Str::slug($title);

--- a/app/Actions/SaveDonationEventAction.php
+++ b/app/Actions/SaveDonationEventAction.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\DonationEvent;
+
+class SaveDonationEventAction
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function __invoke(?DonationEvent $donationEvent, array $data): DonationEvent
+    {
+        $donationEvent ??= new DonationEvent;
+
+        $content = array_replace_recursive(
+            $donationEvent->content ?? [],
+            is_array($data['content'] ?? null) ? $data['content'] : [],
+        );
+
+        unset($data['content']);
+        unset($data['timezone']);
+
+        $donationEvent->fill([
+            'timezone' => 'Europe/Zurich',
+            ...$data,
+            'content' => $content,
+        ])->save();
+
+        return $donationEvent;
+    }
+}

--- a/app/Actions/SyncDonationEventPartnersAction.php
+++ b/app/Actions/SyncDonationEventPartnersAction.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\AthleteRegistration;
+use App\Models\DonationEvent;
+use App\Models\Partner;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+class SyncDonationEventPartnersAction
+{
+    /**
+     * @param  array<int, array{id: int, attached: bool, sort_order: int, is_published: bool}>  $partnerRows
+     */
+    public function __invoke(DonationEvent $donationEvent, array $partnerRows): void
+    {
+        $rowsByPartnerId = [];
+        $syncData = [];
+
+        foreach ($partnerRows as $partnerRow) {
+            $partnerId = $partnerRow['id'];
+            $rowsByPartnerId[$partnerId] = $partnerRow;
+
+            if ($partnerRow['attached']) {
+                $syncData[$partnerId] = $this->pivotData($partnerRow);
+            }
+        }
+
+        $referencedPartnerIds = AthleteRegistration::query()
+            ->whereBelongsTo($donationEvent)
+            ->whereNotNull('partner_id')
+            ->distinct()
+            ->pluck('partner_id');
+
+        $existingReferencedPartners = $donationEvent->partners()
+            ->whereKey($referencedPartnerIds)
+            ->get()
+            ->keyBy('id');
+
+        foreach ($referencedPartnerIds as $referencedPartnerId) {
+            $partnerId = (int) $referencedPartnerId;
+
+            if (isset($rowsByPartnerId[$partnerId])) {
+                $syncData[$partnerId] = $this->pivotData($rowsByPartnerId[$partnerId]);
+
+                continue;
+            }
+
+            $existingPartner = $existingReferencedPartners->get($partnerId);
+            $pivot = $existingPartner instanceof Partner ? $existingPartner->getRelation('pivot') : null;
+            $syncData[$partnerId] = [
+                'sort_order' => (int) ($pivot instanceof Pivot ? $pivot->getAttribute('sort_order') : 0),
+                'is_published' => (bool) ($pivot instanceof Pivot ? $pivot->getAttribute('is_published') : true),
+            ];
+        }
+
+        $donationEvent->partners()->syncOrFail($syncData);
+    }
+
+    /**
+     * @param  array{id: int, attached: bool, sort_order: int, is_published: bool}  $partnerRow
+     * @return array{sort_order: int, is_published: bool}
+     */
+    protected function pivotData(array $partnerRow): array
+    {
+        return [
+            'sort_order' => $partnerRow['sort_order'],
+            'is_published' => $partnerRow['is_published'],
+        ];
+    }
+}

--- a/app/Actions/SyncDonationEventPartnersAction.php
+++ b/app/Actions/SyncDonationEventPartnersAction.php
@@ -42,7 +42,11 @@ class SyncDonationEventPartnersAction
         foreach ($referencedPartnerIds as $referencedPartnerId) {
             $partnerId = (int) $referencedPartnerId;
 
-            if (isset($rowsByPartnerId[$partnerId])) {
+            if (
+                isset($rowsByPartnerId[$partnerId])
+                && array_key_exists('sort_order', $rowsByPartnerId[$partnerId])
+                && array_key_exists('is_published', $rowsByPartnerId[$partnerId])
+            ) {
                 $syncData[$partnerId] = $this->pivotData($rowsByPartnerId[$partnerId]);
 
                 continue;
@@ -52,7 +56,7 @@ class SyncDonationEventPartnersAction
             $pivot = $existingPartner instanceof Partner ? $existingPartner->getRelation('pivot') : null;
             $syncData[$partnerId] = [
                 'sort_order' => (int) ($pivot instanceof Pivot ? $pivot->getAttribute('sort_order') : 0),
-                'is_published' => (bool) ($pivot instanceof Pivot ? $pivot->getAttribute('is_published') : true),
+                'is_published' => (bool) ($pivot instanceof Pivot ? $pivot->getAttribute('is_published') : false),
             ];
         }
 

--- a/app/Actions/SyncDonationEventSponsorsAction.php
+++ b/app/Actions/SyncDonationEventSponsorsAction.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions;
+
+use App\Models\DonationEvent;
+
+class SyncDonationEventSponsorsAction
+{
+    /**
+     * @param  array<int, array{id: int, attached: bool, size: string, contribution_text: string|null, sort_order: int, is_published: bool}>  $sponsorRows
+     */
+    public function __invoke(DonationEvent $donationEvent, array $sponsorRows): void
+    {
+        $syncData = [];
+
+        foreach ($sponsorRows as $sponsorRow) {
+            if (! $sponsorRow['attached']) {
+                continue;
+            }
+
+            $syncData[$sponsorRow['id']] = [
+                'size' => $sponsorRow['size'],
+                'contribution_text' => trim((string) $sponsorRow['contribution_text']),
+                'sort_order' => $sponsorRow['sort_order'],
+                'is_published' => $sponsorRow['is_published'],
+            ];
+        }
+
+        $donationEvent->sponsors()->syncOrFail($syncData);
+    }
+}

--- a/app/Components/AdminDonationEventForm.php
+++ b/app/Components/AdminDonationEventForm.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Components;
+
+use App\Actions\SaveDonationEventAction;
+use App\Models\DonationEvent;
+use Flux;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+use Livewire\Component;
+
+class AdminDonationEventForm extends Component
+{
+    public ?DonationEvent $donationEvent = null;
+
+    /** @var array<string, mixed> */
+    public array $form = [];
+
+    public function mount(?DonationEvent $donationEvent = null): void
+    {
+        $this->donationEvent = $donationEvent;
+        $this->form = $this->formValues($donationEvent);
+    }
+
+    public function render(): Factory|View
+    {
+        return view('components.admin-donation-event-form');
+    }
+
+    public function save(SaveDonationEventAction $saveDonationEvent): void
+    {
+        abort_unless(Auth::check(), 403);
+
+        $isCreating = ! $this->donationEvent instanceof DonationEvent;
+        $validated = $this->validate($this->rules(), [], $this->validationAttributes());
+
+        $this->donationEvent = $saveDonationEvent($this->donationEvent, $validated['form']);
+        $this->form = $this->formValues($this->donationEvent);
+
+        Flux::toast(
+            heading: 'Gespeichert',
+            text: $isCreating ? 'Anlass wurde erstellt.' : 'Anlass wurde aktualisiert.',
+            variant: 'success',
+        );
+
+        if ($isCreating) {
+            $this->redirect(route('admin.donation-events.edit', $this->donationEvent), navigate: true);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function rules(): array
+    {
+        return [
+            'form.title' => ['required', 'string', 'max:255'],
+            'form.slug' => ['required', 'string', 'max:255', Rule::unique(DonationEvent::class, 'slug')->ignore($this->donationEvent)],
+            'form.starts_at' => ['required', 'date'],
+            'form.ends_at' => ['required', 'date', 'after:form.starts_at'],
+            'form.registration_opens_at' => ['nullable', 'date'],
+            'form.athlete_registration_closes_at' => ['nullable', 'date', 'after_or_equal:form.registration_opens_at'],
+            'form.donor_registration_closes_at' => ['nullable', 'date', 'after_or_equal:form.registration_opens_at'],
+            'form.location_name' => ['nullable', 'string', 'max:255'],
+            'form.location_street' => ['nullable', 'string', 'max:255'],
+            'form.location_postal_code' => ['nullable', 'string', 'max:255'],
+            'form.location_city' => ['required', 'string', 'max:255'],
+            'form.location_url' => ['nullable', 'url', 'max:255'],
+            'form.is_published' => ['boolean'],
+            'form.has_equal_split_option' => ['boolean'],
+            'form.content.hero.copy_md' => ['nullable', 'string'],
+            'form.content.home.about_heading' => ['nullable', 'string', 'max:255'],
+            'form.content.home.about_intro_md' => ['nullable', 'string'],
+            'form.content.home.about_body_md' => ['nullable', 'string'],
+            'form.content.results.heading_md' => ['nullable', 'string', 'max:255'],
+            'form.content.seo.meta_description_md' => ['nullable', 'string'],
+            'form.content.seo.og_description_md' => ['nullable', 'string'],
+            'form.content.invoice.additional_information' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function validationAttributes(): array
+    {
+        return [
+            'form.title' => 'Titel',
+            'form.slug' => 'Kürzel',
+            'form.starts_at' => 'Start',
+            'form.ends_at' => 'Ende',
+            'form.registration_opens_at' => 'Anmeldestart',
+            'form.athlete_registration_closes_at' => 'Anmeldeschluss Sportler:innen',
+            'form.donor_registration_closes_at' => 'Anmeldeschluss Spender:innen',
+            'form.location_city' => 'Stadt',
+            'form.location_url' => 'Kartenlink',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function formValues(?DonationEvent $donationEvent): array
+    {
+        if (! $donationEvent instanceof DonationEvent) {
+            return [
+                'title' => '',
+                'slug' => '',
+                'starts_at' => '',
+                'ends_at' => '',
+                'registration_opens_at' => '',
+                'athlete_registration_closes_at' => '',
+                'donor_registration_closes_at' => '',
+                'location_name' => '',
+                'location_street' => '',
+                'location_postal_code' => '',
+                'location_city' => '',
+                'location_url' => '',
+                'is_published' => false,
+                'has_equal_split_option' => true,
+                'content' => $this->contentValues(null),
+            ];
+        }
+
+        return [
+            'title' => $donationEvent->title,
+            'slug' => $donationEvent->slug,
+            'starts_at' => $this->dateTimeValue($donationEvent->starts_at),
+            'ends_at' => $this->dateTimeValue($donationEvent->ends_at),
+            'registration_opens_at' => $this->dateTimeValue($donationEvent->registration_opens_at),
+            'athlete_registration_closes_at' => $this->dateTimeValue($donationEvent->athlete_registration_closes_at),
+            'donor_registration_closes_at' => $this->dateTimeValue($donationEvent->donor_registration_closes_at),
+            'location_name' => $donationEvent->location_name ?? '',
+            'location_street' => $donationEvent->location_street ?? '',
+            'location_postal_code' => $donationEvent->location_postal_code ?? '',
+            'location_city' => $donationEvent->location_city,
+            'location_url' => $donationEvent->location_url ?? '',
+            'is_published' => $donationEvent->is_published,
+            'has_equal_split_option' => $donationEvent->has_equal_split_option,
+            'content' => $this->contentValues($donationEvent),
+        ];
+    }
+
+    /**
+     * @return array<string, array<string, string>>
+     */
+    protected function contentValues(?DonationEvent $donationEvent): array
+    {
+        return [
+            'hero' => [
+                'copy_md' => $donationEvent?->contentValue('hero.copy_md') ?? '',
+            ],
+            'home' => [
+                'about_heading' => $donationEvent?->contentValue('home.about_heading') ?? '',
+                'about_intro_md' => $donationEvent?->contentValue('home.about_intro_md') ?? '',
+                'about_body_md' => $donationEvent?->contentValue('home.about_body_md') ?? '',
+            ],
+            'results' => [
+                'heading_md' => $donationEvent?->contentValue('results.heading_md') ?? '',
+            ],
+            'seo' => [
+                'meta_description_md' => $donationEvent?->contentValue('seo.meta_description_md') ?? '',
+                'og_description_md' => $donationEvent?->contentValue('seo.og_description_md') ?? '',
+            ],
+            'invoice' => [
+                'additional_information' => $donationEvent?->contentValue('invoice.additional_information') ?? '',
+            ],
+        ];
+    }
+
+    protected function dateTimeValue(mixed $value): string
+    {
+        return is_object($value) && method_exists($value, 'format')
+            ? $value->format('Y-m-d\\TH:i:s')
+            : '';
+    }
+}

--- a/app/Components/AdminDonationEventForm.php
+++ b/app/Components/AdminDonationEventForm.php
@@ -140,8 +140,21 @@ class AdminDonationEventForm extends Component
             'form.registration_opens_at' => 'Anmeldestart',
             'form.athlete_registration_closes_at' => 'Anmeldeschluss Sportler:innen',
             'form.donor_registration_closes_at' => 'Anmeldeschluss Spender:innen',
+            'form.location_name' => 'Name des Veranstaltungsorts',
+            'form.location_street' => 'Strasse',
+            'form.location_postal_code' => 'PLZ',
             'form.location_city' => 'Stadt',
             'form.location_url' => 'Kartenlink',
+            'form.is_published' => 'Veröffentlichung',
+            'form.has_equal_split_option' => 'Spendenaufteilung',
+            'form.content.hero.copy_md' => 'Hero-Text',
+            'form.content.home.about_heading' => 'Homepage-Überschrift',
+            'form.content.home.about_intro_md' => 'Homepage-Einleitung',
+            'form.content.home.about_body_md' => 'Homepage-Haupttext',
+            'form.content.results.heading_md' => 'Resultate-Überschrift',
+            'form.content.seo.meta_description_md' => 'SEO-Beschreibung',
+            'form.content.seo.og_description_md' => 'OpenGraph-Beschreibung',
+            'form.content.invoice.additional_information' => 'Zusatzinformation Spendenrechnung',
         ];
     }
 

--- a/app/Components/AdminDonationEventForm.php
+++ b/app/Components/AdminDonationEventForm.php
@@ -6,11 +6,13 @@ namespace App\Components;
 
 use App\Actions\SaveDonationEventAction;
 use App\Models\DonationEvent;
+use App\Settings\EventSettings;
 use Flux;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
 class AdminDonationEventForm extends Component
@@ -20,9 +22,14 @@ class AdminDonationEventForm extends Component
     /** @var array<string, mixed> */
     public array $form = [];
 
-    public function mount(?DonationEvent $donationEvent = null): void
+    public bool $isCurrentEvent = false;
+
+    public bool $hasUnsavedChanges = false;
+
+    public function mount(?DonationEvent $donationEvent = null, bool $isCurrentEvent = false): void
     {
         $this->donationEvent = $donationEvent;
+        $this->isCurrentEvent = $isCurrentEvent;
         $this->form = $this->formValues($donationEvent);
     }
 
@@ -35,11 +42,50 @@ class AdminDonationEventForm extends Component
     {
         abort_unless(Auth::check(), 403);
 
-        $isCreating = ! $this->donationEvent instanceof DonationEvent;
-        $validated = $this->validate($this->rules(), [], $this->validationAttributes());
+        try {
+            $validated = $this->validate($this->rules(), [], $this->validationAttributes());
+        } catch (ValidationException $validationException) {
+            $this->hasUnsavedChanges = true;
 
-        $this->donationEvent = $saveDonationEvent($this->donationEvent, $validated['form']);
+            throw $validationException;
+        }
+
+        if ($this->requiresUnpublishedConfirmation()) {
+            $this->hasUnsavedChanges = true;
+            Flux::modal('confirm-current-event-unpublish')->show();
+
+            return;
+        }
+
+        $this->persist($saveDonationEvent, $validated['form']);
+    }
+
+    public function confirmUnpublished(SaveDonationEventAction $saveDonationEvent): void
+    {
+        abort_unless(Auth::check(), 403);
+
+        $validated = $this->validate($this->rules(), [], $this->validationAttributes());
+        $this->persist($saveDonationEvent, $validated['form']);
+    }
+
+    protected function requiresUnpublishedConfirmation(): bool
+    {
+        return $this->donationEvent instanceof DonationEvent
+            && $this->donationEvent->is_published
+            && ! (bool) $this->form['is_published']
+            && resolve(EventSettings::class)->current_event_id === $this->donationEvent->id;
+    }
+
+    /**
+     * @param  array<string, mixed>  $form
+     */
+    protected function persist(SaveDonationEventAction $saveDonationEvent, array $form): void
+    {
+        $isCreating = ! $this->donationEvent instanceof DonationEvent;
+
+        $this->donationEvent = $saveDonationEvent($this->donationEvent, $form);
         $this->form = $this->formValues($this->donationEvent);
+        $this->hasUnsavedChanges = false;
 
         Flux::toast(
             heading: 'Gespeichert',
@@ -47,9 +93,7 @@ class AdminDonationEventForm extends Component
             variant: 'success',
         );
 
-        if ($isCreating) {
-            $this->redirect(route('admin.donation-events.edit', $this->donationEvent), navigate: true);
-        }
+        $this->redirect(route('admin.donation-events.edit', $this->donationEvent), navigate: true);
     }
 
     /**
@@ -90,7 +134,7 @@ class AdminDonationEventForm extends Component
     {
         return [
             'form.title' => 'Titel',
-            'form.slug' => 'Kürzel',
+            'form.slug' => 'Slug',
             'form.starts_at' => 'Start',
             'form.ends_at' => 'Ende',
             'form.registration_opens_at' => 'Anmeldestart',
@@ -139,8 +183,8 @@ class AdminDonationEventForm extends Component
             'location_postal_code' => $donationEvent->location_postal_code ?? '',
             'location_city' => $donationEvent->location_city,
             'location_url' => $donationEvent->location_url ?? '',
-            'is_published' => $donationEvent->is_published,
-            'has_equal_split_option' => $donationEvent->has_equal_split_option,
+            'is_published' => (bool) $donationEvent->is_published,
+            'has_equal_split_option' => (bool) $donationEvent->has_equal_split_option,
             'content' => $this->contentValues($donationEvent),
         ];
     }

--- a/app/Components/AdminDonationEventPartnersForm.php
+++ b/app/Components/AdminDonationEventPartnersForm.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Components;
+
+use App\Actions\SyncDonationEventPartnersAction;
+use App\Models\AthleteRegistration;
+use App\Models\DonationEvent;
+use App\Models\Partner;
+use Flux;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+use Livewire\Component;
+
+class AdminDonationEventPartnersForm extends Component
+{
+    public DonationEvent $donationEvent;
+
+    /**
+     * @var array<int, array{id: int, name: string, attached: bool, sort_order: int, is_published: bool, is_locked: bool, registration_count: int}>
+     */
+    public array $partnerRows = [];
+
+    public function mount(DonationEvent $donationEvent): void
+    {
+        $this->donationEvent = $donationEvent;
+        $this->loadPartnerRows();
+    }
+
+    public function render(): Factory|View
+    {
+        return view('components.admin-donation-event-partners-form');
+    }
+
+    public function save(SyncDonationEventPartnersAction $syncDonationEventPartners): void
+    {
+        abort_unless(Auth::check(), 403);
+
+        $validated = $this->validate($this->rules());
+
+        $syncDonationEventPartners($this->donationEvent, $validated['partnerRows']);
+        $this->loadPartnerRows();
+
+        Flux::toast(
+            heading: 'Gespeichert',
+            text: 'Partner:innen wurden aktualisiert.',
+            variant: 'success',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function rules(): array
+    {
+        return [
+            'partnerRows' => ['array'],
+            'partnerRows.*.id' => ['required', 'integer', 'distinct:strict', Rule::exists(Partner::class, 'id')],
+            'partnerRows.*.attached' => ['required', 'boolean'],
+            'partnerRows.*.sort_order' => ['required', 'integer', 'min:0'],
+            'partnerRows.*.is_published' => ['required', 'boolean'],
+        ];
+    }
+
+    protected function loadPartnerRows(): void
+    {
+        $assignedPartners = $this->donationEvent->partners()->get()->keyBy('id');
+        $registrationCounts = AthleteRegistration::query()
+            ->whereBelongsTo($this->donationEvent)
+            ->whereNotNull('partner_id')
+            ->selectRaw('partner_id, COUNT(*) as aggregate')
+            ->groupBy('partner_id')
+            ->pluck('aggregate', 'partner_id');
+
+        $this->partnerRows = Partner::query()
+            ->orderBy('name')
+            ->get()
+            ->values()
+            ->map(function (Partner $partner, int $index) use ($assignedPartners, $registrationCounts): array {
+                $assignedPartner = $assignedPartners->get($partner->id);
+                $pivot = $assignedPartner instanceof Partner ? $assignedPartner->getRelation('pivot') : null;
+                $registrationCount = (int) $registrationCounts->get($partner->id, 0);
+
+                return [
+                    'id' => $partner->id,
+                    'name' => $partner->name,
+                    'attached' => $assignedPartner instanceof Partner || $registrationCount > 0,
+                    'sort_order' => $pivot instanceof Pivot
+                        ? (int) $pivot->getAttribute('sort_order')
+                        : ($index + 1) * 10,
+                    'is_published' => $pivot instanceof Pivot
+                        ? (bool) $pivot->getAttribute('is_published')
+                        : true,
+                    'is_locked' => $registrationCount > 0,
+                    'registration_count' => $registrationCount,
+                ];
+            })
+            ->all();
+    }
+}

--- a/app/Components/AdminDonationEventPartnersForm.php
+++ b/app/Components/AdminDonationEventPartnersForm.php
@@ -72,6 +72,15 @@ class AdminDonationEventPartnersForm extends Component
         $this->hasUnsavedChanges = true;
     }
 
+    public function detachPartner(int $index): void
+    {
+        abort_unless(Auth::check(), 403);
+        abort_unless(isset($this->partnerRows[$index]), 404);
+
+        $this->partnerRows[$index]['attached'] = false;
+        $this->hasUnsavedChanges = true;
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/app/Components/AdminDonationEventPartnersForm.php
+++ b/app/Components/AdminDonationEventPartnersForm.php
@@ -14,6 +14,7 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
 class AdminDonationEventPartnersForm extends Component
@@ -21,9 +22,11 @@ class AdminDonationEventPartnersForm extends Component
     public DonationEvent $donationEvent;
 
     /**
-     * @var array<int, array{id: int, name: string, attached: bool, sort_order: int, is_published: bool, is_locked: bool, registration_count: int}>
+     * @var array<int, array{id: int, name: string, attached: bool, was_attached: bool, sort_order: int, is_published: bool, is_locked: bool, registration_count: int}>
      */
     public array $partnerRows = [];
+
+    public bool $hasUnsavedChanges = false;
 
     public function mount(DonationEvent $donationEvent): void
     {
@@ -40,10 +43,17 @@ class AdminDonationEventPartnersForm extends Component
     {
         abort_unless(Auth::check(), 403);
 
-        $validated = $this->validate($this->rules());
+        try {
+            $validated = $this->validate($this->rules(), [], $this->validationAttributes());
+        } catch (ValidationException $validationException) {
+            $this->hasUnsavedChanges = true;
+
+            throw $validationException;
+        }
 
         $syncDonationEventPartners($this->donationEvent, $validated['partnerRows']);
         $this->loadPartnerRows();
+        $this->hasUnsavedChanges = false;
 
         Flux::toast(
             heading: 'Gespeichert',
@@ -52,18 +62,52 @@ class AdminDonationEventPartnersForm extends Component
         );
     }
 
+    public function attachPartner(int $index): void
+    {
+        abort_unless(Auth::check(), 403);
+        abort_unless(isset($this->partnerRows[$index]), 404);
+
+        $this->partnerRows[$index]['attached'] = true;
+        $this->partnerRows[$index]['is_published'] = false;
+        $this->hasUnsavedChanges = true;
+    }
+
     /**
      * @return array<string, mixed>
      */
     protected function rules(): array
     {
-        return [
+        $rules = [
             'partnerRows' => ['array'],
             'partnerRows.*.id' => ['required', 'integer', 'distinct:strict', Rule::exists(Partner::class, 'id')],
             'partnerRows.*.attached' => ['required', 'boolean'],
-            'partnerRows.*.sort_order' => ['required', 'integer', 'min:0'],
-            'partnerRows.*.is_published' => ['required', 'boolean'],
         ];
+
+        foreach ($this->partnerRows as $index => $partnerRow) {
+            if (! $partnerRow['attached'] && ! $partnerRow['is_locked']) {
+                continue;
+            }
+
+            $rules[sprintf('partnerRows.%d.sort_order', $index)] = ['required', 'integer', 'min:0'];
+            $rules[sprintf('partnerRows.%d.is_published', $index)] = ['required', 'boolean'];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function validationAttributes(): array
+    {
+        $attributes = [];
+
+        foreach ($this->partnerRows as $index => $partnerRow) {
+            $attributes[sprintf('partnerRows.%d.sort_order', $index)] = 'Reihenfolge für '.$partnerRow['name'];
+            $attributes[sprintf('partnerRows.%d.is_published', $index)] = 'Veröffentlichung für '.$partnerRow['name'];
+        }
+
+        return $attributes;
     }
 
     protected function loadPartnerRows(): void
@@ -76,11 +120,17 @@ class AdminDonationEventPartnersForm extends Component
             ->groupBy('partner_id')
             ->pluck('aggregate', 'partner_id');
 
+        $nextSortOrder = ((int) $assignedPartners->max(function (Partner $partner): int {
+            $pivot = $partner->getRelation('pivot');
+
+            return $pivot instanceof Pivot ? (int) $pivot->getAttribute('sort_order') : 0;
+        })) + 10;
+
         $this->partnerRows = Partner::query()
             ->orderBy('name')
             ->get()
             ->values()
-            ->map(function (Partner $partner, int $index) use ($assignedPartners, $registrationCounts): array {
+            ->map(function (Partner $partner) use ($assignedPartners, $registrationCounts, $nextSortOrder): array {
                 $assignedPartner = $assignedPartners->get($partner->id);
                 $pivot = $assignedPartner instanceof Partner ? $assignedPartner->getRelation('pivot') : null;
                 $registrationCount = (int) $registrationCounts->get($partner->id, 0);
@@ -89,16 +139,27 @@ class AdminDonationEventPartnersForm extends Component
                     'id' => $partner->id,
                     'name' => $partner->name,
                     'attached' => $assignedPartner instanceof Partner || $registrationCount > 0,
+                    'was_attached' => $assignedPartner instanceof Partner || $registrationCount > 0,
                     'sort_order' => $pivot instanceof Pivot
                         ? (int) $pivot->getAttribute('sort_order')
-                        : ($index + 1) * 10,
-                    'is_published' => $pivot instanceof Pivot
-                        ? (bool) $pivot->getAttribute('is_published')
-                        : true,
+                        : $nextSortOrder,
+                    'is_published' => $pivot instanceof Pivot && (bool) $pivot->getAttribute('is_published'),
                     'is_locked' => $registrationCount > 0,
                     'registration_count' => $registrationCount,
                 ];
             })
+            ->sort(function (array $left, array $right): int {
+                if ($left['attached'] !== $right['attached']) {
+                    return $left['attached'] ? -1 : 1;
+                }
+
+                if ($left['attached'] && $left['sort_order'] !== $right['sort_order']) {
+                    return $left['sort_order'] <=> $right['sort_order'];
+                }
+
+                return strcasecmp($left['name'], $right['name']);
+            })
+            ->values()
             ->all();
     }
 }

--- a/app/Components/AdminDonationEventSponsorsForm.php
+++ b/app/Components/AdminDonationEventSponsorsForm.php
@@ -71,6 +71,15 @@ class AdminDonationEventSponsorsForm extends Component
         $this->hasUnsavedChanges = true;
     }
 
+    public function detachSponsor(int $index): void
+    {
+        abort_unless(Auth::check(), 403);
+        abort_unless(isset($this->sponsorRows[$index]), 404);
+
+        $this->sponsorRows[$index]['attached'] = false;
+        $this->hasUnsavedChanges = true;
+    }
+
     /**
      * @return array<string, mixed>
      */

--- a/app/Components/AdminDonationEventSponsorsForm.php
+++ b/app/Components/AdminDonationEventSponsorsForm.php
@@ -13,16 +13,19 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
+use Illuminate\Validation\ValidationException;
 use Livewire\Component;
 
 class AdminDonationEventSponsorsForm extends Component
 {
     /**
-     * @var array<int, array{id: int, name: string, attached: bool, size: string, contribution_text: string, sort_order: int, is_published: bool}>
+     * @var array<int, array{id: int, name: string, attached: bool, was_attached: bool, size: string, contribution_text: string, sort_order: int, is_published: bool}>
      */
     public array $sponsorRows = [];
 
     public DonationEvent $donationEvent;
+
+    public bool $hasUnsavedChanges = false;
 
     public function mount(DonationEvent $donationEvent): void
     {
@@ -39,10 +42,17 @@ class AdminDonationEventSponsorsForm extends Component
     {
         abort_unless(Auth::check(), 403);
 
-        $validated = $this->validate($this->rules());
+        try {
+            $validated = $this->validate($this->rules(), [], $this->validationAttributes());
+        } catch (ValidationException $validationException) {
+            $this->hasUnsavedChanges = true;
+
+            throw $validationException;
+        }
 
         $syncDonationEventSponsors($this->donationEvent, $validated['sponsorRows']);
         $this->loadSponsorRows();
+        $this->hasUnsavedChanges = false;
 
         Flux::toast(
             heading: 'Gespeichert',
@@ -51,31 +61,73 @@ class AdminDonationEventSponsorsForm extends Component
         );
     }
 
+    public function attachSponsor(int $index): void
+    {
+        abort_unless(Auth::check(), 403);
+        abort_unless(isset($this->sponsorRows[$index]), 404);
+
+        $this->sponsorRows[$index]['attached'] = true;
+        $this->sponsorRows[$index]['is_published'] = false;
+        $this->hasUnsavedChanges = true;
+    }
+
     /**
      * @return array<string, mixed>
      */
     protected function rules(): array
     {
-        return [
+        $rules = [
             'sponsorRows' => ['array'],
             'sponsorRows.*.id' => ['required', 'integer', 'distinct:strict', Rule::exists(Sponsor::class, 'id')],
             'sponsorRows.*.attached' => ['required', 'boolean'],
-            'sponsorRows.*.size' => ['required', 'string', Rule::in(['small', 'medium', 'large'])],
-            'sponsorRows.*.contribution_text' => ['nullable', 'required_if:sponsorRows.*.attached,true', 'string'],
-            'sponsorRows.*.sort_order' => ['required', 'integer', 'min:0'],
-            'sponsorRows.*.is_published' => ['required', 'boolean'],
         ];
+
+        foreach ($this->sponsorRows as $index => $sponsorRow) {
+            if (! $sponsorRow['attached']) {
+                continue;
+            }
+
+            $rules[sprintf('sponsorRows.%d.size', $index)] = ['required', 'string', Rule::in(['small', 'medium', 'large'])];
+            $rules[sprintf('sponsorRows.%d.contribution_text', $index)] = ['required', 'string'];
+            $rules[sprintf('sponsorRows.%d.sort_order', $index)] = ['required', 'integer', 'min:0'];
+            $rules[sprintf('sponsorRows.%d.is_published', $index)] = ['required', 'boolean'];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function validationAttributes(): array
+    {
+        $attributes = [];
+
+        foreach ($this->sponsorRows as $index => $sponsorRow) {
+            $attributes[sprintf('sponsorRows.%d.size', $index)] = 'Grösse für '.$sponsorRow['name'];
+            $attributes[sprintf('sponsorRows.%d.contribution_text', $index)] = 'Beitrag für '.$sponsorRow['name'];
+            $attributes[sprintf('sponsorRows.%d.sort_order', $index)] = 'Reihenfolge für '.$sponsorRow['name'];
+            $attributes[sprintf('sponsorRows.%d.is_published', $index)] = 'Veröffentlichung für '.$sponsorRow['name'];
+        }
+
+        return $attributes;
     }
 
     protected function loadSponsorRows(): void
     {
         $assignedSponsors = $this->donationEvent->sponsors()->get()->keyBy('id');
 
+        $nextSortOrder = ((int) $assignedSponsors->max(function (Sponsor $sponsor): int {
+            $pivot = $sponsor->getRelation('pivot');
+
+            return $pivot instanceof Pivot ? (int) $pivot->getAttribute('sort_order') : 0;
+        })) + 10;
+
         $this->sponsorRows = Sponsor::query()
             ->orderBy('name')
             ->get()
             ->values()
-            ->map(function (Sponsor $sponsor, int $index) use ($assignedSponsors): array {
+            ->map(function (Sponsor $sponsor) use ($assignedSponsors, $nextSortOrder): array {
                 $assignedSponsor = $assignedSponsors->get($sponsor->id);
                 $pivot = $assignedSponsor instanceof Sponsor ? $assignedSponsor->getRelation('pivot') : null;
 
@@ -83,16 +135,27 @@ class AdminDonationEventSponsorsForm extends Component
                     'id' => $sponsor->id,
                     'name' => $sponsor->name,
                     'attached' => $assignedSponsor instanceof Sponsor,
+                    'was_attached' => $assignedSponsor instanceof Sponsor,
                     'size' => (string) ($pivot instanceof Pivot ? $pivot->getAttribute('size') : 'medium'),
                     'contribution_text' => (string) ($pivot instanceof Pivot ? $pivot->getAttribute('contribution_text') : ''),
                     'sort_order' => $pivot instanceof Pivot
                         ? (int) $pivot->getAttribute('sort_order')
-                        : ($index + 1) * 10,
-                    'is_published' => $pivot instanceof Pivot
-                        ? (bool) $pivot->getAttribute('is_published')
-                        : true,
+                        : $nextSortOrder,
+                    'is_published' => $pivot instanceof Pivot && (bool) $pivot->getAttribute('is_published'),
                 ];
             })
+            ->sort(function (array $left, array $right): int {
+                if ($left['attached'] !== $right['attached']) {
+                    return $left['attached'] ? -1 : 1;
+                }
+
+                if ($left['attached'] && $left['sort_order'] !== $right['sort_order']) {
+                    return $left['sort_order'] <=> $right['sort_order'];
+                }
+
+                return strcasecmp($left['name'], $right['name']);
+            })
+            ->values()
             ->all();
     }
 }

--- a/app/Components/AdminDonationEventSponsorsForm.php
+++ b/app/Components/AdminDonationEventSponsorsForm.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Components;
+
+use App\Actions\SyncDonationEventSponsorsAction;
+use App\Models\DonationEvent;
+use App\Models\Sponsor;
+use Flux;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+use Livewire\Component;
+
+class AdminDonationEventSponsorsForm extends Component
+{
+    /**
+     * @var array<int, array{id: int, name: string, attached: bool, size: string, contribution_text: string, sort_order: int, is_published: bool}>
+     */
+    public array $sponsorRows = [];
+
+    public DonationEvent $donationEvent;
+
+    public function mount(DonationEvent $donationEvent): void
+    {
+        $this->donationEvent = $donationEvent;
+        $this->loadSponsorRows();
+    }
+
+    public function render(): Factory|View
+    {
+        return view('components.admin-donation-event-sponsors-form');
+    }
+
+    public function save(SyncDonationEventSponsorsAction $syncDonationEventSponsors): void
+    {
+        abort_unless(Auth::check(), 403);
+
+        $validated = $this->validate($this->rules());
+
+        $syncDonationEventSponsors($this->donationEvent, $validated['sponsorRows']);
+        $this->loadSponsorRows();
+
+        Flux::toast(
+            heading: 'Gespeichert',
+            text: 'Sponsor:innen wurden aktualisiert.',
+            variant: 'success',
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function rules(): array
+    {
+        return [
+            'sponsorRows' => ['array'],
+            'sponsorRows.*.id' => ['required', 'integer', 'distinct:strict', Rule::exists(Sponsor::class, 'id')],
+            'sponsorRows.*.attached' => ['required', 'boolean'],
+            'sponsorRows.*.size' => ['required', 'string', Rule::in(['small', 'medium', 'large'])],
+            'sponsorRows.*.contribution_text' => ['nullable', 'required_if:sponsorRows.*.attached,true', 'string'],
+            'sponsorRows.*.sort_order' => ['required', 'integer', 'min:0'],
+            'sponsorRows.*.is_published' => ['required', 'boolean'],
+        ];
+    }
+
+    protected function loadSponsorRows(): void
+    {
+        $assignedSponsors = $this->donationEvent->sponsors()->get()->keyBy('id');
+
+        $this->sponsorRows = Sponsor::query()
+            ->orderBy('name')
+            ->get()
+            ->values()
+            ->map(function (Sponsor $sponsor, int $index) use ($assignedSponsors): array {
+                $assignedSponsor = $assignedSponsors->get($sponsor->id);
+                $pivot = $assignedSponsor instanceof Sponsor ? $assignedSponsor->getRelation('pivot') : null;
+
+                return [
+                    'id' => $sponsor->id,
+                    'name' => $sponsor->name,
+                    'attached' => $assignedSponsor instanceof Sponsor,
+                    'size' => (string) ($pivot instanceof Pivot ? $pivot->getAttribute('size') : 'medium'),
+                    'contribution_text' => (string) ($pivot instanceof Pivot ? $pivot->getAttribute('contribution_text') : ''),
+                    'sort_order' => $pivot instanceof Pivot
+                        ? (int) $pivot->getAttribute('sort_order')
+                        : ($index + 1) * 10,
+                    'is_published' => $pivot instanceof Pivot
+                        ? (bool) $pivot->getAttribute('is_published')
+                        : true,
+                ];
+            })
+            ->all();
+    }
+}

--- a/app/Components/AdminDonationEventTable.php
+++ b/app/Components/AdminDonationEventTable.php
@@ -115,7 +115,7 @@ class AdminDonationEventTable extends AbstractDatatableComponent
     protected function columnDefinitions(): array
     {
         return [
-            'slug' => ['label' => 'Jahr', 'sortable' => true, 'align' => 'left', 'width' => 'min-w-24', 'export_key' => 'Jahr'],
+            'slug' => ['label' => 'Slug', 'sortable' => true, 'align' => 'left', 'width' => 'min-w-24', 'export_key' => 'Slug'],
             'title' => ['label' => 'Titel', 'sortable' => true, 'align' => 'left', 'width' => 'min-w-56', 'export_key' => 'Titel'],
             'starts_at' => ['label' => 'Start', 'sortable' => true, 'align' => 'left', 'width' => 'min-w-40', 'export_key' => 'Start', 'formatter' => 'datetime_or_dash'],
             'ends_at' => ['label' => 'Ende', 'sortable' => true, 'align' => 'left', 'width' => 'min-w-40', 'export_key' => 'Ende', 'formatter' => 'datetime_or_dash'],
@@ -154,7 +154,7 @@ class AdminDonationEventTable extends AbstractDatatableComponent
     protected function exportRow(DonationEvent $donationEvent): array
     {
         return [
-            'Jahr' => $donationEvent->slug,
+            'Slug' => $donationEvent->slug,
             'Titel' => $donationEvent->title,
             'Start' => $this->formatDateTimeOrNull($donationEvent->starts_at),
             'Ende' => $this->formatDateTimeOrNull($donationEvent->ends_at),

--- a/app/Http/Controllers/Admin/DonationEventSettingsController.php
+++ b/app/Http/Controllers/Admin/DonationEventSettingsController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\DonationEvent;
+use App\Settings\EventSettings;
 use Illuminate\Contracts\View\Factory;
 use Illuminate\Contracts\View\View;
 
@@ -16,10 +17,11 @@ class DonationEventSettingsController extends Controller
         return view('pages.admin.donation-event-settings');
     }
 
-    public function edit(DonationEvent $donationEvent): Factory|View
+    public function edit(DonationEvent $donationEvent, EventSettings $eventSettings): Factory|View
     {
         return view('pages.admin.donation-event-settings', [
             'donationEvent' => $donationEvent,
+            'isCurrentEvent' => $eventSettings->current_event_id === $donationEvent->id,
         ]);
     }
 }

--- a/app/Http/Controllers/Admin/DonationEventSettingsController.php
+++ b/app/Http/Controllers/Admin/DonationEventSettingsController.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\DonationEvent;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+
+class DonationEventSettingsController extends Controller
+{
+    public function create(): Factory|View
+    {
+        return view('pages.admin.donation-event-settings');
+    }
+
+    public function edit(DonationEvent $donationEvent): Factory|View
+    {
+        return view('pages.admin.donation-event-settings', [
+            'donationEvent' => $donationEvent,
+        ]);
+    }
+}

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -24,19 +24,6 @@ function sanitizeImageSrc(rawValue) {
     return url.toString();
 }
 
-function hasUnsavedAdminSettingsChanges() {
-    if (!window.location.pathname.startsWith("/admin/einstellungen")) {
-        return false;
-    }
-
-    const root = document.querySelector("[data-admin-settings-root]");
-    if (!root) {
-        return false;
-    }
-
-    return root.querySelector("[data-admin-settings-save-class-button]:not([disabled])") !== null;
-}
-
 function initHeroLqip(scope = document) {
     const heroes = scope.querySelectorAll(".hfm-hero");
     heroes.forEach((hero) => {
@@ -94,25 +81,5 @@ document.addEventListener("livewire:navigated", () => {
                 element.scrollIntoView({ behavior: "smooth", block: "start", inline: "nearest" });
             }, 100);
         }
-    }
-});
-
-window.addEventListener("beforeunload", (event) => {
-    if (!hasUnsavedAdminSettingsChanges()) {
-        return;
-    }
-
-    event.preventDefault();
-    event.returnValue = "";
-});
-
-document.addEventListener("livewire:navigate", (event) => {
-    if (!hasUnsavedAdminSettingsChanges()) {
-        return;
-    }
-
-    const shouldLeave = window.confirm("Du hast ungespeicherte Änderungen. Seite trotzdem verlassen?");
-    if (!shouldLeave) {
-        event.preventDefault();
     }
 });

--- a/resources/views/components/admin-donation-event-form.blade.php
+++ b/resources/views/components/admin-donation-event-form.blade.php
@@ -1,9 +1,4 @@
-<form
-    wire:submit="save"
-    class="space-y-6"
-    data-admin-unsaved-form
-    x-bind:data-unsaved="($wire.$dirty() || $wire.hasUnsavedChanges) ? 'true' : 'false'"
->
+<form wire:submit="save" class="space-y-6">
     @if ($errors->any())
         <flux:callout
             variant="danger"

--- a/resources/views/components/admin-donation-event-form.blade.php
+++ b/resources/views/components/admin-donation-event-form.blade.php
@@ -158,7 +158,7 @@
             </div>
 
             <flux:modal.trigger name="donation-event-markdown-help">
-                <flux:button type="button" variant="ghost" size="sm" icon="information-circle">Markdown-Hilfe</flux:button>
+                <flux:button type="button" variant="ghost" size="sm" icon="information-circle" icon:variant="outline">Markdown-Hilfe</flux:button>
             </flux:modal.trigger>
         </div>
 

--- a/resources/views/components/admin-donation-event-form.blade.php
+++ b/resources/views/components/admin-donation-event-form.blade.php
@@ -1,0 +1,268 @@
+<form wire:submit="save" class="space-y-6">
+    <flux:card class="space-y-6">
+        <div>
+            <flux:heading size="lg">Allgemein</flux:heading>
+            <flux:subheading>Identifikation und Veröffentlichung des Anlasses.</flux:subheading>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2">
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Titel</flux:label>
+                    <x-admin.field-info label="Titel" text="Erscheint als Haupttitel im Hero der Startseite und wird in anlassbezogenen Bestätigungen verwendet." />
+                </div>
+                <flux:input wire:model="form.title" />
+                <flux:error name="form.title" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Kürzel</flux:label>
+                    <x-admin.field-info label="Kürzel" text="Eindeutige interne Kennung des Anlasses. Sie erscheint als Jahr in der Admin-Tabelle und in Exporten." />
+                </div>
+                <flux:input wire:model="form.slug" placeholder="2027" />
+                <flux:error name="form.slug" />
+            </flux:field>
+
+            <flux:field variant="inline">
+                <flux:switch wire:model="form.is_published" />
+                <div class="flex items-center gap-1">
+                    <flux:label>Veröffentlicht</flux:label>
+                    <x-admin.field-info label="Veröffentlicht" text="Nur ein veröffentlichter Anlass kann als aktueller Anlass auf öffentlichen Seiten und in den Anmeldungen verwendet werden." />
+                </div>
+            </flux:field>
+
+            <flux:field variant="inline">
+                <flux:switch wire:model="form.has_equal_split_option" />
+                <div class="flex items-center gap-1">
+                    <flux:label>Gleichmässige Spendenaufteilung anbieten</flux:label>
+                    <x-admin.field-info label="Gleichmässige Spendenaufteilung" text="Steuert, ob Sportler:innen ihre Spenden in der Anmeldung gleichmässig auf alle Benefizpartner:innen verteilen können." />
+                </div>
+            </flux:field>
+        </div>
+    </flux:card>
+
+    <flux:card class="space-y-6">
+        <div>
+            <flux:heading size="lg">Zeitplan</flux:heading>
+            <flux:subheading>Alle Zeitangaben werden in der Zeitzone Europe/Zurich erfasst.</flux:subheading>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2">
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Start</flux:label>
+                    <x-admin.field-info label="Start" text="Startzeit des Anlasses. Das Datum erscheint zusammen mit der Stadt im Hero der Startseite." />
+                </div>
+                <flux:input type="datetime-local" step="1" wire:model="form.starts_at" />
+                <flux:error name="form.starts_at" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Ende</flux:label>
+                    <x-admin.field-info label="Ende" text="Endzeit des Anlasses. Sie wird derzeit in der Admin-Tabelle und in Exporten ausgegeben." />
+                </div>
+                <flux:input type="datetime-local" step="1" wire:model="form.ends_at" />
+                <flux:error name="form.ends_at" />
+            </flux:field>
+
+            <flux:field class="sm:col-span-2">
+                <div class="flex items-center gap-1">
+                    <flux:label>Anmeldung offen ab</flux:label>
+                    <x-admin.field-info label="Anmeldung offen ab" text="Ab diesem Zeitpunkt können Anmeldungen geöffnet sein. Zusätzlich gilt der jeweilige Anmeldeschluss." />
+                </div>
+                <flux:input type="datetime-local" step="1" wire:model="form.registration_opens_at" />
+                <flux:error name="form.registration_opens_at" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Anmeldung Sportler:innen bis</flux:label>
+                    <x-admin.field-info label="Anmeldeschluss Sportler:innen" text="Nach diesem Zeitpunkt ist die Anmeldung als Sportler:in für diesen Anlass geschlossen." />
+                </div>
+                <flux:input type="datetime-local" step="1" wire:model="form.athlete_registration_closes_at" />
+                <flux:error name="form.athlete_registration_closes_at" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Anmeldung Spender:innen bis</flux:label>
+                    <x-admin.field-info label="Anmeldeschluss Spender:innen" text="Nach diesem Zeitpunkt ist die Anmeldung als Spender:in für diesen Anlass geschlossen." />
+                </div>
+                <flux:input type="datetime-local" step="1" wire:model="form.donor_registration_closes_at" />
+                <flux:error name="form.donor_registration_closes_at" />
+            </flux:field>
+        </div>
+    </flux:card>
+
+    <flux:card class="space-y-6">
+        <div>
+            <flux:heading size="lg">Ort</flux:heading>
+            <flux:subheading>Veranstaltungsort und Kartenlink.</flux:subheading>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-2">
+            <flux:field class="sm:col-span-2">
+                <div class="flex items-center gap-1">
+                    <flux:label>Name</flux:label>
+                    <x-admin.field-info label="Name des Veranstaltungsorts" text="Bezeichnung des Veranstaltungsorts. Sie wird derzeit in der Admin-Tabelle und in Exporten verwendet." />
+                </div>
+                <flux:input wire:model="form.location_name" />
+                <flux:error name="form.location_name" />
+            </flux:field>
+
+            <flux:field class="sm:col-span-2">
+                <div class="flex items-center gap-1">
+                    <flux:label>Strasse</flux:label>
+                    <x-admin.field-info label="Strasse" text="Strasse des Veranstaltungsorts. Sie wird derzeit in der Admin-Tabelle und in Exporten verwendet." />
+                </div>
+                <flux:input wire:model="form.location_street" />
+                <flux:error name="form.location_street" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>PLZ</flux:label>
+                    <x-admin.field-info label="PLZ" text="Postleitzahl des Veranstaltungsorts. Sie wird derzeit in der Admin-Tabelle und in Exporten verwendet." />
+                </div>
+                <flux:input wire:model="form.location_postal_code" />
+                <flux:error name="form.location_postal_code" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Stadt</flux:label>
+                    <x-admin.field-info label="Stadt" text="Erscheint zusammen mit dem Startdatum im Hero der Startseite." />
+                </div>
+                <flux:input wire:model="form.location_city" />
+                <flux:error name="form.location_city" />
+            </flux:field>
+
+            <flux:field class="sm:col-span-2">
+                <div class="flex items-center gap-1">
+                    <flux:label>Kartenlink</flux:label>
+                    <x-admin.field-info label="Kartenlink" text="Link zur Karte des Veranstaltungsorts. Er wird derzeit in der Admin-Tabelle und in Exporten verwendet." />
+                </div>
+                <flux:input wire:model="form.location_url" />
+                <flux:error name="form.location_url" />
+            </flux:field>
+        </div>
+    </flux:card>
+
+    <flux:card class="space-y-6">
+        <div class="flex flex-wrap items-start justify-between gap-3">
+            <div>
+                <flux:heading size="lg">Öffentliche Inhalte</flux:heading>
+                <flux:subheading>Unbekannte Inhaltsfelder bleiben beim Speichern erhalten.</flux:subheading>
+            </div>
+
+            <flux:modal.trigger name="donation-event-markdown-help">
+                <flux:button type="button" variant="ghost" size="sm" icon="information-circle">Markdown-Hilfe</flux:button>
+            </flux:modal.trigger>
+        </div>
+
+        <div class="grid gap-4">
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Hero-Text</flux:label>
+                    <x-admin.field-info label="Hero-Text" text="Erscheint direkt unter dem Anlass-Titel im Hero der Startseite. Inline-Markdown für Hervorhebungen und Links wird unterstützt." />
+                </div>
+                <flux:textarea rows="3" wire:model="form.content.hero.copy_md" />
+                <flux:error name="form.content.hero.copy_md" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Homepage-Überschrift</flux:label>
+                    <x-admin.field-info label="Homepage-Überschrift" text="Erscheint als Überschrift im Informationsbereich unterhalb des Hero-Bereichs auf der Startseite." />
+                </div>
+                <flux:input wire:model="form.content.home.about_heading" />
+                <flux:error name="form.content.home.about_heading" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Homepage-Einleitung</flux:label>
+                    <x-admin.field-info label="Homepage-Einleitung" text="Erscheint hervorgehoben direkt unter der Homepage-Überschrift. Markdown wird unterstützt." />
+                </div>
+                <flux:textarea rows="4" wire:model="form.content.home.about_intro_md" />
+                <flux:error name="form.content.home.about_intro_md" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Homepage-Haupttext</flux:label>
+                    <x-admin.field-info label="Homepage-Haupttext" text="Erscheint im Informationsbereich der Startseite vor den Hinweisen zur Teilnahme. Markdown wird unterstützt." />
+                </div>
+                <flux:textarea rows="6" wire:model="form.content.home.about_body_md" />
+                <flux:error name="form.content.home.about_body_md" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Resultate-Überschrift</flux:label>
+                    <x-admin.field-info label="Resultate-Überschrift" text="Erscheint als Seitentitel auf der öffentlichen Resultate-Seite. Formatierung wird dort als reiner Text ausgegeben." />
+                </div>
+                <flux:input wire:model="form.content.results.heading_md" />
+                <flux:error name="form.content.results.heading_md" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>SEO-Beschreibung</flux:label>
+                    <x-admin.field-info label="SEO-Beschreibung" text="Wird als Meta-Beschreibung für Suchmaschinen ausgegeben. Formatierung wird entfernt; nur Text bleibt bestehen." />
+                </div>
+                <flux:textarea rows="3" wire:model="form.content.seo.meta_description_md" />
+                <flux:error name="form.content.seo.meta_description_md" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>OpenGraph-Beschreibung</flux:label>
+                    <x-admin.field-info label="OpenGraph-Beschreibung" text="Wird als Beschreibung beim Teilen der Website verwendet. Formatierung wird entfernt; nur Text bleibt bestehen." />
+                </div>
+                <flux:textarea rows="3" wire:model="form.content.seo.og_description_md" />
+                <flux:error name="form.content.seo.og_description_md" />
+            </flux:field>
+
+            <flux:field>
+                <div class="flex items-center gap-1">
+                    <flux:label>Zusatzinformation Spendenrechnung</flux:label>
+                    <x-admin.field-info label="Zusatzinformation Spendenrechnung" text="Ist für anlassbezogene Rechnungstexte vorgesehen, wird derzeit aber noch nicht automatisch auf einer Rechnung ausgegeben." />
+                </div>
+                <flux:textarea rows="3" wire:model="form.content.invoice.additional_information" />
+                <flux:error name="form.content.invoice.additional_information" />
+            </flux:field>
+        </div>
+    </flux:card>
+
+    <flux:modal name="donation-event-markdown-help" class="space-y-6 md:w-xl">
+        <div>
+            <flux:heading size="lg">Markdown-Syntax</flux:heading>
+            <flux:subheading>Für Hero-Text, Homepage-Einleitung und Homepage-Haupttext.</flux:subheading>
+        </div>
+
+        <div class="grid gap-3 text-sm sm:grid-cols-2">
+            <code>**fett**</code><span><strong>fett</strong></span>
+            <code>*kursiv*</code><span><em>kursiv</em></span>
+            <code>[Linktext](https://example.org)</code><span>Link</span>
+            <code>- Listeneintrag</code><span>Aufzählung</span>
+            <code>## Überschrift</code><span>Zwischenüberschrift</span>
+            <code>Leerzeile</code><span>Neuer Absatz</span>
+        </div>
+
+        <flux:callout icon="shield-check">
+            HTML wird entfernt. Unsichere Links werden nicht ausgegeben. Im Hero funktionieren nur Inline-Formatierungen wie fett, kursiv und Links.
+        </flux:callout>
+    </flux:modal>
+
+    <div class="flex items-center gap-3">
+        <flux:text wire:dirty class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+        <flux:spacer />
+        <flux:button type="submit" variant="primary" wire:target="save" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="save">{{ $donationEvent === null ? 'Anlass erstellen' : 'Änderungen speichern' }}</span>
+            <span wire:loading wire:target="save">Speichert...</span>
+        </flux:button>
+    </div>
+</form>

--- a/resources/views/components/admin-donation-event-form.blade.php
+++ b/resources/views/components/admin-donation-event-form.blade.php
@@ -1,4 +1,25 @@
-<form wire:submit="save" class="space-y-6">
+<form
+    wire:submit="save"
+    class="space-y-6"
+    data-admin-unsaved-form
+    x-bind:data-unsaved="($wire.$dirty() || $wire.hasUnsavedChanges) ? 'true' : 'false'"
+>
+    @if ($errors->any())
+        <flux:callout
+            variant="danger"
+            icon="exclamation-triangle"
+            heading="Bitte überprüfe deine Eingaben"
+            tabindex="-1"
+            x-init="$nextTick(() => { const field = $el.parentElement.querySelector('[aria-invalid=true]'); (field ?? $el).scrollIntoView({ behavior: 'smooth', block: 'center' }); (field ?? $el).focus(); })"
+        >
+            <ul class="list-disc space-y-1 pl-5">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </flux:callout>
+    @endif
+
     <flux:card class="space-y-6">
         <div>
             <flux:heading size="lg">Allgemein</flux:heading>
@@ -8,21 +29,33 @@
         <div class="grid gap-4 sm:grid-cols-2">
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Titel</flux:label>
+                    <flux:label badge="Pflichtfeld">Titel</flux:label>
                     <x-admin.field-info label="Titel" text="Erscheint als Haupttitel im Hero der Startseite und wird in anlassbezogenen Bestätigungen verwendet." />
                 </div>
-                <flux:input wire:model="form.title" />
+                <flux:input wire:model="form.title" required />
                 <flux:error name="form.title" />
             </flux:field>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Kürzel</flux:label>
-                    <x-admin.field-info label="Kürzel" text="Eindeutige interne Kennung des Anlasses. Sie erscheint als Jahr in der Admin-Tabelle und in Exporten." />
+                    <flux:label badge="Pflichtfeld">Slug</flux:label>
+                    <x-admin.field-info label="Slug" text="Eindeutige, flexible Kennung des Anlasses für Admin-Tabelle und Exporte." />
                 </div>
-                <flux:input wire:model="form.slug" placeholder="2027" />
+                <flux:input wire:model="form.slug" placeholder="hfm-2027" required />
                 <flux:error name="form.slug" />
             </flux:field>
+
+            @if ($isCurrentEvent)
+                <flux:callout
+                    class="sm:col-span-2"
+                    variant="danger"
+                    icon="exclamation-triangle"
+                    x-cloak
+                    x-show="!$wire.form.is_published"
+                >
+                    Dieser Anlass ist als aktueller Anlass gesetzt. Beim Aufheben der Veröffentlichung bleiben öffentliche Event-Inhalte und Anmeldungen geschlossen.
+                </flux:callout>
+            @endif
 
             <flux:field variant="inline">
                 <flux:switch wire:model="form.is_published" />
@@ -48,28 +81,32 @@
             <flux:subheading>Alle Zeitangaben werden in der Zeitzone Europe/Zurich erfasst.</flux:subheading>
         </div>
 
+        <flux:callout icon="information-circle">
+            Leere Anmeldedaten halten die entsprechende Anmeldung geschlossen. Erst mit Anmeldestart und passendem Anmeldeschluss kann sie geöffnet werden.
+        </flux:callout>
+
         <div class="grid gap-4 sm:grid-cols-2">
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Start</flux:label>
+                    <flux:label badge="Pflichtfeld">Start</flux:label>
                     <x-admin.field-info label="Start" text="Startzeit des Anlasses. Das Datum erscheint zusammen mit der Stadt im Hero der Startseite." />
                 </div>
-                <flux:input type="datetime-local" step="1" wire:model="form.starts_at" />
+                <flux:input type="datetime-local" step="1" wire:model="form.starts_at" required />
                 <flux:error name="form.starts_at" />
             </flux:field>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Ende</flux:label>
+                    <flux:label badge="Pflichtfeld">Ende</flux:label>
                     <x-admin.field-info label="Ende" text="Endzeit des Anlasses. Sie wird derzeit in der Admin-Tabelle und in Exporten ausgegeben." />
                 </div>
-                <flux:input type="datetime-local" step="1" wire:model="form.ends_at" />
+                <flux:input type="datetime-local" step="1" wire:model="form.ends_at" required />
                 <flux:error name="form.ends_at" />
             </flux:field>
 
             <flux:field class="sm:col-span-2">
                 <div class="flex items-center gap-1">
-                    <flux:label>Anmeldung offen ab</flux:label>
+                    <flux:label badge="Optional">Anmeldung offen ab</flux:label>
                     <x-admin.field-info label="Anmeldung offen ab" text="Ab diesem Zeitpunkt können Anmeldungen geöffnet sein. Zusätzlich gilt der jeweilige Anmeldeschluss." />
                 </div>
                 <flux:input type="datetime-local" step="1" wire:model="form.registration_opens_at" />
@@ -78,7 +115,7 @@
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Anmeldung Sportler:innen bis</flux:label>
+                    <flux:label badge="Optional">Anmeldung Sportler:innen bis</flux:label>
                     <x-admin.field-info label="Anmeldeschluss Sportler:innen" text="Nach diesem Zeitpunkt ist die Anmeldung als Sportler:in für diesen Anlass geschlossen." />
                 </div>
                 <flux:input type="datetime-local" step="1" wire:model="form.athlete_registration_closes_at" />
@@ -87,7 +124,7 @@
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Anmeldung Spender:innen bis</flux:label>
+                    <flux:label badge="Optional">Anmeldung Spender:innen bis</flux:label>
                     <x-admin.field-info label="Anmeldeschluss Spender:innen" text="Nach diesem Zeitpunkt ist die Anmeldung als Spender:in für diesen Anlass geschlossen." />
                 </div>
                 <flux:input type="datetime-local" step="1" wire:model="form.donor_registration_closes_at" />
@@ -105,7 +142,7 @@
         <div class="grid gap-4 sm:grid-cols-2">
             <flux:field class="sm:col-span-2">
                 <div class="flex items-center gap-1">
-                    <flux:label>Name</flux:label>
+                    <flux:label badge="Optional">Name</flux:label>
                     <x-admin.field-info label="Name des Veranstaltungsorts" text="Bezeichnung des Veranstaltungsorts. Sie wird derzeit in der Admin-Tabelle und in Exporten verwendet." />
                 </div>
                 <flux:input wire:model="form.location_name" />
@@ -114,7 +151,7 @@
 
             <flux:field class="sm:col-span-2">
                 <div class="flex items-center gap-1">
-                    <flux:label>Strasse</flux:label>
+                    <flux:label badge="Optional">Strasse</flux:label>
                     <x-admin.field-info label="Strasse" text="Strasse des Veranstaltungsorts. Sie wird derzeit in der Admin-Tabelle und in Exporten verwendet." />
                 </div>
                 <flux:input wire:model="form.location_street" />
@@ -123,28 +160,28 @@
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>PLZ</flux:label>
+                    <flux:label badge="Optional">PLZ</flux:label>
                     <x-admin.field-info label="PLZ" text="Postleitzahl des Veranstaltungsorts. Sie wird derzeit in der Admin-Tabelle und in Exporten verwendet." />
                 </div>
-                <flux:input wire:model="form.location_postal_code" />
+                <flux:input wire:model="form.location_postal_code" inputmode="numeric" autocomplete="postal-code" />
                 <flux:error name="form.location_postal_code" />
             </flux:field>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Stadt</flux:label>
+                    <flux:label badge="Pflichtfeld">Stadt</flux:label>
                     <x-admin.field-info label="Stadt" text="Erscheint zusammen mit dem Startdatum im Hero der Startseite." />
                 </div>
-                <flux:input wire:model="form.location_city" />
+                <flux:input wire:model="form.location_city" required />
                 <flux:error name="form.location_city" />
             </flux:field>
 
             <flux:field class="sm:col-span-2">
                 <div class="flex items-center gap-1">
-                    <flux:label>Kartenlink</flux:label>
+                    <flux:label badge="Optional">Kartenlink</flux:label>
                     <x-admin.field-info label="Kartenlink" text="Link zur Karte des Veranstaltungsorts. Er wird derzeit in der Admin-Tabelle und in Exporten verwendet." />
                 </div>
-                <flux:input wire:model="form.location_url" />
+                <flux:input type="url" wire:model="form.location_url" placeholder="https://maps.example.org/..." />
                 <flux:error name="form.location_url" />
             </flux:field>
         </div>
@@ -162,55 +199,78 @@
             </flux:modal.trigger>
         </div>
 
-        <div class="grid gap-4">
+        <div class="space-y-8">
+            <section class="grid gap-4">
+                <div>
+                    <flux:heading>Startseite</flux:heading>
+                    <flux:subheading>Hero und Informationsbereich der öffentlichen Startseite.</flux:subheading>
+                </div>
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Hero-Text</flux:label>
+                    <flux:label badge="Optional">Hero-Text</flux:label>
                     <x-admin.field-info label="Hero-Text" text="Erscheint direkt unter dem Anlass-Titel im Hero der Startseite. Inline-Markdown für Hervorhebungen und Links wird unterstützt." />
                 </div>
-                <flux:textarea rows="3" wire:model="form.content.hero.copy_md" />
+                <flux:textarea rows="3" wire:model="form.content.hero.copy_md" placeholder="Gemeinsam Höhenmeter sammeln und lokale Projekte unterstützen." />
                 <flux:error name="form.content.hero.copy_md" />
             </flux:field>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Homepage-Überschrift</flux:label>
+                    <flux:label badge="Optional">Homepage-Überschrift</flux:label>
                     <x-admin.field-info label="Homepage-Überschrift" text="Erscheint als Überschrift im Informationsbereich unterhalb des Hero-Bereichs auf der Startseite." />
                 </div>
-                <flux:input wire:model="form.content.home.about_heading" />
+                <flux:input wire:model="form.content.home.about_heading" placeholder="Darum geht es" />
                 <flux:error name="form.content.home.about_heading" />
             </flux:field>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Homepage-Einleitung</flux:label>
+                    <flux:label badge="Optional">Homepage-Einleitung</flux:label>
                     <x-admin.field-info label="Homepage-Einleitung" text="Erscheint hervorgehoben direkt unter der Homepage-Überschrift. Markdown wird unterstützt." />
                 </div>
-                <flux:textarea rows="4" wire:model="form.content.home.about_intro_md" />
+                <flux:textarea rows="4" wire:model="form.content.home.about_intro_md" placeholder="Kurze Einführung zum Anlass und seinem Zweck." />
                 <flux:error name="form.content.home.about_intro_md" />
             </flux:field>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Homepage-Haupttext</flux:label>
+                    <flux:label badge="Optional">Homepage-Haupttext</flux:label>
                     <x-admin.field-info label="Homepage-Haupttext" text="Erscheint im Informationsbereich der Startseite vor den Hinweisen zur Teilnahme. Markdown wird unterstützt." />
                 </div>
-                <flux:textarea rows="6" wire:model="form.content.home.about_body_md" />
+                <flux:textarea rows="6" wire:model="form.content.home.about_body_md" placeholder="Weitere Informationen zu Teilnahme, Strecke und unterstützten Projekten." />
                 <flux:error name="form.content.home.about_body_md" />
             </flux:field>
+            </section>
+
+            <flux:separator />
+
+            <section class="grid gap-4">
+                <div>
+                    <flux:heading>Resultate</flux:heading>
+                    <flux:subheading>Text für die öffentliche Resultate-Seite.</flux:subheading>
+                </div>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Resultate-Überschrift</flux:label>
+                    <flux:label badge="Optional">Resultate-Überschrift</flux:label>
                     <x-admin.field-info label="Resultate-Überschrift" text="Erscheint als Seitentitel auf der öffentlichen Resultate-Seite. Formatierung wird dort als reiner Text ausgegeben." />
                 </div>
                 <flux:input wire:model="form.content.results.heading_md" />
                 <flux:error name="form.content.results.heading_md" />
             </flux:field>
+            </section>
+
+            <flux:separator />
+
+            <section class="grid gap-4">
+                <div>
+                    <flux:heading>SEO / Teilen</flux:heading>
+                    <flux:subheading>Beschreibungen für Suchmaschinen und soziale Netzwerke.</flux:subheading>
+                </div>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>SEO-Beschreibung</flux:label>
+                    <flux:label badge="Optional">SEO-Beschreibung</flux:label>
                     <x-admin.field-info label="SEO-Beschreibung" text="Wird als Meta-Beschreibung für Suchmaschinen ausgegeben. Formatierung wird entfernt; nur Text bleibt bestehen." />
                 </div>
                 <flux:textarea rows="3" wire:model="form.content.seo.meta_description_md" />
@@ -219,21 +279,31 @@
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>OpenGraph-Beschreibung</flux:label>
+                    <flux:label badge="Optional">OpenGraph-Beschreibung</flux:label>
                     <x-admin.field-info label="OpenGraph-Beschreibung" text="Wird als Beschreibung beim Teilen der Website verwendet. Formatierung wird entfernt; nur Text bleibt bestehen." />
                 </div>
                 <flux:textarea rows="3" wire:model="form.content.seo.og_description_md" />
                 <flux:error name="form.content.seo.og_description_md" />
             </flux:field>
+            </section>
+
+            <flux:separator />
+
+            <section class="grid gap-4">
+                <div>
+                    <flux:heading>Rechnung</flux:heading>
+                    <flux:subheading>Zusätzliche anlassbezogene Rechnungsinformation.</flux:subheading>
+                </div>
 
             <flux:field>
                 <div class="flex items-center gap-1">
-                    <flux:label>Zusatzinformation Spendenrechnung</flux:label>
+                    <flux:label badge="Optional">Zusatzinformation Spendenrechnung</flux:label>
                     <x-admin.field-info label="Zusatzinformation Spendenrechnung" text="Ist für anlassbezogene Rechnungstexte vorgesehen, wird derzeit aber noch nicht automatisch auf einer Rechnung ausgegeben." />
                 </div>
                 <flux:textarea rows="3" wire:model="form.content.invoice.additional_information" />
                 <flux:error name="form.content.invoice.additional_information" />
             </flux:field>
+            </section>
         </div>
     </flux:card>
 
@@ -257,12 +327,63 @@
         </flux:callout>
     </flux:modal>
 
-    <div class="flex items-center gap-3">
-        <flux:text wire:dirty class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+    @php
+        $dirtyEventFields = [
+            'form.title' => 'Titel',
+            'form.slug' => 'Slug',
+            'form.is_published' => 'Veröffentlichung',
+            'form.has_equal_split_option' => 'Spendenaufteilung',
+            'form.starts_at' => 'Start',
+            'form.ends_at' => 'Ende',
+            'form.registration_opens_at' => 'Anmeldestart',
+            'form.athlete_registration_closes_at' => 'Anmeldeschluss Sportler:innen',
+            'form.donor_registration_closes_at' => 'Anmeldeschluss Spender:innen',
+            'form.location_name' => 'Ort',
+            'form.location_street' => 'Strasse',
+            'form.location_postal_code' => 'PLZ',
+            'form.location_city' => 'Stadt',
+            'form.location_url' => 'Kartenlink',
+            'form.content.hero.copy_md' => 'Hero-Text',
+            'form.content.home.about_heading' => 'Homepage-Überschrift',
+            'form.content.home.about_intro_md' => 'Homepage-Einleitung',
+            'form.content.home.about_body_md' => 'Homepage-Haupttext',
+            'form.content.results.heading_md' => 'Resultate',
+            'form.content.seo.meta_description_md' => 'SEO',
+            'form.content.seo.og_description_md' => 'OpenGraph',
+            'form.content.invoice.additional_information' => 'Rechnung',
+        ];
+    @endphp
+
+    <div class="sticky bottom-0 z-20 flex items-center gap-3 border-t border-zinc-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/95">
+        <div x-cloak x-show="$wire.$dirty() || $wire.hasUnsavedChanges" class="space-y-1.5">
+            <flux:text class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+            <div class="flex flex-wrap gap-1.5">
+                @foreach ($dirtyEventFields as $property => $label)
+                    <flux:badge size="sm" x-cloak x-show="$wire.$dirty(@js($property))">{{ $label }}</flux:badge>
+                @endforeach
+                <flux:badge size="sm" x-cloak x-show="$wire.hasUnsavedChanges && !$wire.$dirty()">Formularangaben</flux:badge>
+            </div>
+        </div>
         <flux:spacer />
         <flux:button type="submit" variant="primary" wire:target="save" wire:loading.attr="disabled">
             <span wire:loading.remove wire:target="save">{{ $donationEvent === null ? 'Anlass erstellen' : 'Änderungen speichern' }}</span>
             <span wire:loading wire:target="save">Speichert...</span>
         </flux:button>
     </div>
+
+    <flux:modal name="confirm-current-event-unpublish" class="md:w-lg" :dismissible="false">
+        <div class="space-y-6">
+            <div>
+                <flux:heading size="lg">Aktuellen Anlass nicht mehr veröffentlichen?</flux:heading>
+                <flux:text class="mt-2">Öffentliche Event-Inhalte und Anmeldungen bleiben geschlossen, solange dieser aktuelle Anlass nicht veröffentlicht ist.</flux:text>
+            </div>
+            <div class="flex gap-2">
+                <flux:spacer />
+                <flux:modal.close>
+                    <flux:button type="button" variant="ghost">Abbrechen</flux:button>
+                </flux:modal.close>
+                <flux:button type="button" variant="danger" wire:click="confirmUnpublished">Trotzdem speichern</flux:button>
+            </div>
+        </div>
+    </flux:modal>
 </form>

--- a/resources/views/components/admin-donation-event-partners-form.blade.php
+++ b/resources/views/components/admin-donation-event-partners-form.blade.php
@@ -1,0 +1,76 @@
+<form wire:submit="save" class="space-y-6">
+    <flux:card class="space-y-6">
+        <div class="space-y-2">
+            <flux:heading size="lg">Partner:innen zuordnen</flux:heading>
+            <flux:subheading>Zuordnung, Sichtbarkeit und Reihenfolge gelten nur für diesen Anlass.</flux:subheading>
+        </div>
+
+        <flux:callout icon="information-circle">
+            Veröffentlichte Partner:innen erscheinen auf der Startseite und stehen Sportler:innen bei der Anmeldung zur Auswahl. Partner:innen mit bestehenden Anmeldungen können nicht entfernt werden.
+        </flux:callout>
+
+        @forelse ($partnerRows as $index => $partnerRow)
+            <div wire:key="event-partner-{{ $partnerRow['id'] }}" class="grid gap-4 border-t border-zinc-200 pt-5 dark:border-zinc-700 lg:grid-cols-[minmax(12rem,1fr)_2fr]">
+                <div class="space-y-2">
+                    <flux:heading>{{ $partnerRow['name'] }}</flux:heading>
+
+                    @if ($partnerRow['is_locked'])
+                        <flux:badge size="sm" icon="lock-closed" color="amber">
+                            {{ $partnerRow['registration_count'] }} {{ $partnerRow['registration_count'] === 1 ? 'Anmeldung' : 'Anmeldungen' }}
+                        </flux:badge>
+                        <flux:text class="text-xs">Bleibt zugeordnet, solange Anmeldungen diese Partner:in verwenden.</flux:text>
+                    @endif
+                </div>
+
+                <div class="grid items-start gap-4 sm:grid-cols-3">
+                    <flux:switch
+                        wire:model.live="partnerRows.{{ $index }}.attached"
+                        label="Zugeordnet"
+                        description="Verknüpft diese Partner:in mit dem Anlass."
+                        :disabled="$partnerRow['is_locked']"
+                    />
+
+                    <flux:switch
+                        wire:model="partnerRows.{{ $index }}.is_published"
+                        label="Veröffentlicht"
+                        description="Sichtbar auf Startseite und in Anmeldung."
+                        :disabled="! $partnerRow['attached']"
+                    />
+
+                    <flux:field>
+                        <div class="flex items-center gap-1">
+                            <flux:label>Reihenfolge</flux:label>
+                            <x-admin.field-info label="Reihenfolge" text="Kleinere Zahlen erscheinen zuerst. Bei gleicher Zahl wird nach Name sortiert." />
+                        </div>
+                        <flux:input
+                            type="number"
+                            min="0"
+                            step="1"
+                            wire:model="partnerRows.{{ $index }}.sort_order"
+                            :disabled="! $partnerRow['attached']"
+                        />
+                        <flux:error name="partnerRows.{{ $index }}.sort_order" />
+                    </flux:field>
+                </div>
+
+                <flux:error name="partnerRows.{{ $index }}.id" />
+                <flux:error name="partnerRows.{{ $index }}.attached" />
+                <flux:error name="partnerRows.{{ $index }}.is_published" />
+            </div>
+        @empty
+            <flux:callout icon="user-group" heading="Keine Partner:innen vorhanden">
+                Erfasse zuerst Partner:innen in der Partner:innen-Verwaltung.
+                <flux:callout.link href="{{ route('admin.partners.index') }}" wire:navigate.hover>Partner:innen verwalten</flux:callout.link>
+            </flux:callout>
+        @endforelse
+    </flux:card>
+
+    <div class="flex items-center gap-3">
+        <flux:text wire:dirty class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+        <flux:spacer />
+        <flux:button type="submit" variant="primary" wire:target="save" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="save">Partner:innen speichern</span>
+            <span wire:loading wire:target="save">Speichert...</span>
+        </flux:button>
+    </div>
+</form>

--- a/resources/views/components/admin-donation-event-partners-form.blade.php
+++ b/resources/views/components/admin-donation-event-partners-form.blade.php
@@ -1,16 +1,42 @@
-<form wire:submit="save" class="space-y-6">
+<form
+    wire:submit="save"
+    class="space-y-6"
+    data-admin-unsaved-form
+    x-bind:data-unsaved="($wire.$dirty() || $wire.hasUnsavedChanges) ? 'true' : 'false'"
+>
+    @if ($errors->any())
+        <flux:callout
+            variant="danger"
+            icon="exclamation-triangle"
+            heading="Bitte überprüfe die Partner:innen"
+            tabindex="-1"
+            x-init="$nextTick(() => { const field = $el.parentElement.querySelector('[aria-invalid=true]'); (field ?? $el).scrollIntoView({ behavior: 'smooth', block: 'center' }); (field ?? $el).focus(); })"
+        >
+            <ul class="list-disc space-y-1 pl-5">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </flux:callout>
+    @endif
+
+    @php
+        $assignedPartnerRows = collect($partnerRows)->filter(fn (array $row): bool => $row['attached'] || $row['was_attached']);
+        $availablePartnerRows = collect($partnerRows)->filter(fn (array $row): bool => ! $row['attached'] && ! $row['was_attached']);
+    @endphp
+
     <flux:card class="space-y-6">
         <div class="space-y-2">
-            <flux:heading size="lg">Partner:innen zuordnen</flux:heading>
-            <flux:subheading>Zuordnung, Sichtbarkeit und Reihenfolge gelten nur für diesen Anlass.</flux:subheading>
+            <flux:heading size="lg">Zugeordnete Partner:innen</flux:heading>
+            <flux:subheading>Sichtbarkeit und Reihenfolge gelten nur für diesen Anlass.</flux:subheading>
         </div>
 
         <flux:callout icon="information-circle">
-            Veröffentlichte Partner:innen erscheinen auf der Startseite und stehen Sportler:innen bei der Anmeldung zur Auswahl. Partner:innen mit bestehenden Anmeldungen können nicht entfernt werden.
+            Veröffentlichte Partner:innen erscheinen auf der Startseite und in der Anmeldung. Partner:innen mit bestehenden Anmeldungen können nicht entfernt werden.
         </flux:callout>
 
-        @forelse ($partnerRows as $index => $partnerRow)
-            <div wire:key="event-partner-{{ $partnerRow['id'] }}" class="grid gap-4 border-t border-zinc-200 pt-5 dark:border-zinc-700 lg:grid-cols-[minmax(12rem,1fr)_2fr]">
+        @forelse ($assignedPartnerRows as $index => $partnerRow)
+            <div wire:key="event-partner-assigned-{{ $partnerRow['id'] }}" class="grid gap-4 border-t border-zinc-200 pt-5 dark:border-zinc-700 lg:grid-cols-[minmax(12rem,1fr)_2fr]">
                 <div class="space-y-2">
                     <flux:heading>{{ $partnerRow['name'] }}</flux:heading>
 
@@ -20,35 +46,41 @@
                         </flux:badge>
                         <flux:text class="text-xs">Bleibt zugeordnet, solange Anmeldungen diese Partner:in verwenden.</flux:text>
                     @endif
+
+                    @if ($partnerRow['was_attached'] && ! $partnerRow['is_locked'])
+                        <flux:switch
+                            wire:model="partnerRows.{{ $index }}.attached"
+                            label="Zugeordnet"
+                            description="Ausschalten, um die Partner:in beim Speichern zu entfernen."
+                        />
+                    @endif
+
+                    @if ($partnerRow['was_attached'] && ! $partnerRow['is_locked'])
+                        <flux:callout
+                            x-cloak
+                            x-show="!$wire.partnerRows[{{ $index }}].attached"
+                            variant="warning"
+                            icon="exclamation-triangle"
+                            heading="Vom Anlass entfernen"
+                        >
+                            Beim Speichern gehen Reihenfolge und Veröffentlichungsstatus dieser Zuordnung verloren.
+                        </flux:callout>
+                    @endif
                 </div>
 
-                <div class="grid items-start gap-4 sm:grid-cols-3">
-                    <flux:switch
-                        wire:model.live="partnerRows.{{ $index }}.attached"
-                        label="Zugeordnet"
-                        description="Verknüpft diese Partner:in mit dem Anlass."
-                        :disabled="$partnerRow['is_locked']"
-                    />
-
+                <div class="grid items-start gap-4 sm:grid-cols-2">
                     <flux:switch
                         wire:model="partnerRows.{{ $index }}.is_published"
                         label="Veröffentlicht"
                         description="Sichtbar auf Startseite und in Anmeldung."
-                        :disabled="! $partnerRow['attached']"
                     />
 
                     <flux:field>
                         <div class="flex items-center gap-1">
-                            <flux:label>Reihenfolge</flux:label>
+                            <flux:label badge="Pflichtfeld">Reihenfolge</flux:label>
                             <x-admin.field-info label="Reihenfolge" text="Kleinere Zahlen erscheinen zuerst. Bei gleicher Zahl wird nach Name sortiert." />
                         </div>
-                        <flux:input
-                            type="number"
-                            min="0"
-                            step="1"
-                            wire:model="partnerRows.{{ $index }}.sort_order"
-                            :disabled="! $partnerRow['attached']"
-                        />
+                        <flux:input type="number" min="0" step="1" wire:model="partnerRows.{{ $index }}.sort_order" required />
                         <flux:error name="partnerRows.{{ $index }}.sort_order" />
                     </flux:field>
                 </div>
@@ -58,15 +90,44 @@
                 <flux:error name="partnerRows.{{ $index }}.is_published" />
             </div>
         @empty
-            <flux:callout icon="user-group" heading="Keine Partner:innen vorhanden">
-                Erfasse zuerst Partner:innen in der Partner:innen-Verwaltung.
-                <flux:callout.link href="{{ route('admin.partners.index') }}" wire:navigate.hover>Partner:innen verwalten</flux:callout.link>
-            </flux:callout>
+            <flux:text>Noch keine Partner:innen zugeordnet.</flux:text>
         @endforelse
     </flux:card>
 
-    <div class="flex items-center gap-3">
-        <flux:text wire:dirty class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+    <flux:card class="space-y-4">
+        <div>
+            <flux:heading size="lg">Verfügbare Partner:innen</flux:heading>
+            <flux:subheading>Neue Zuordnungen sind zunächst nicht veröffentlicht.</flux:subheading>
+        </div>
+
+        @forelse ($availablePartnerRows as $index => $partnerRow)
+            <div wire:key="event-partner-available-{{ $partnerRow['id'] }}" class="flex flex-wrap items-center gap-3 border-t border-zinc-200 pt-4 dark:border-zinc-700">
+                <flux:text class="font-medium">{{ $partnerRow['name'] }}</flux:text>
+                <flux:spacer />
+                <flux:button type="button" size="sm" variant="primary" wire:click="attachPartner({{ $index }})">Zuordnen</flux:button>
+            </div>
+        @empty
+            @if ($partnerRows === [])
+                <flux:callout icon="user-group" heading="Keine Partner:innen vorhanden">
+                    Erfasse zuerst Partner:innen in der Partner:innen-Verwaltung.
+                    <flux:callout.link href="{{ route('admin.partners.index') }}" wire:navigate.hover>Partner:innen verwalten</flux:callout.link>
+                </flux:callout>
+            @else
+                <flux:text>Alle Partner:innen sind zugeordnet.</flux:text>
+            @endif
+        @endforelse
+    </flux:card>
+
+    <div class="sticky bottom-0 z-20 flex items-center gap-3 border-t border-zinc-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/95">
+        <div x-cloak x-show="$wire.$dirty() || $wire.hasUnsavedChanges" class="space-y-1.5">
+            <flux:text class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+            <div class="flex flex-wrap gap-1.5">
+                @foreach ($partnerRows as $index => $partnerRow)
+                    <flux:badge size="sm" x-cloak x-show="$wire.$dirty('partnerRows.{{ $index }}')">{{ $partnerRow['name'] }}</flux:badge>
+                @endforeach
+                <flux:badge size="sm" x-cloak x-show="$wire.hasUnsavedChanges && !$wire.$dirty()">Zuordnungen</flux:badge>
+            </div>
+        </div>
         <flux:spacer />
         <flux:button type="submit" variant="primary" wire:target="save" wire:loading.attr="disabled">
             <span wire:loading.remove wire:target="save">Partner:innen speichern</span>

--- a/resources/views/components/admin-donation-event-partners-form.blade.php
+++ b/resources/views/components/admin-donation-event-partners-form.blade.php
@@ -1,9 +1,4 @@
-<form
-    wire:submit="save"
-    class="space-y-6"
-    data-admin-unsaved-form
-    x-bind:data-unsaved="($wire.$dirty() || $wire.hasUnsavedChanges) ? 'true' : 'false'"
->
+<form wire:submit="save" class="space-y-6">
     @if ($errors->any())
         <flux:callout
             variant="danger"
@@ -55,6 +50,12 @@
                         />
                     @endif
 
+                    @if (! $partnerRow['was_attached'])
+                        <flux:button type="button" size="sm" variant="ghost" wire:click="detachPartner({{ $index }})">
+                            Zuordnung rückgängig
+                        </flux:button>
+                    @endif
+
                     @if ($partnerRow['was_attached'] && ! $partnerRow['is_locked'])
                         <flux:callout
                             x-cloak
@@ -71,6 +72,7 @@
                 <div class="grid items-start gap-4 sm:grid-cols-2">
                     <flux:switch
                         wire:model="partnerRows.{{ $index }}.is_published"
+                        x-bind:disabled="!$wire.partnerRows[{{ $index }}].attached"
                         label="Veröffentlicht"
                         description="Sichtbar auf Startseite und in Anmeldung."
                     />
@@ -80,7 +82,14 @@
                             <flux:label badge="Pflichtfeld">Reihenfolge</flux:label>
                             <x-admin.field-info label="Reihenfolge" text="Kleinere Zahlen erscheinen zuerst. Bei gleicher Zahl wird nach Name sortiert." />
                         </div>
-                        <flux:input type="number" min="0" step="1" wire:model="partnerRows.{{ $index }}.sort_order" required />
+                        <flux:input
+                            type="number"
+                            min="0"
+                            step="1"
+                            wire:model="partnerRows.{{ $index }}.sort_order"
+                            x-bind:disabled="!$wire.partnerRows[{{ $index }}].attached"
+                            required
+                        />
                         <flux:error name="partnerRows.{{ $index }}.sort_order" />
                     </flux:field>
                 </div>

--- a/resources/views/components/admin-donation-event-sponsors-form.blade.php
+++ b/resources/views/components/admin-donation-event-sponsors-form.blade.php
@@ -1,9 +1,4 @@
-<form
-    wire:submit="save"
-    class="space-y-6"
-    data-admin-unsaved-form
-    x-bind:data-unsaved="($wire.$dirty() || $wire.hasUnsavedChanges) ? 'true' : 'false'"
->
+<form wire:submit="save" class="space-y-6">
     @if ($errors->any())
         <flux:callout
             variant="danger"
@@ -56,17 +51,28 @@
                             Beim Speichern gehen Grösse, Anlassbeitrag, Reihenfolge und Veröffentlichungsstatus verloren.
                         </flux:callout>
                     @endif
+
+                    @if (! $sponsorRow['was_attached'])
+                        <flux:button type="button" size="sm" variant="ghost" wire:click="detachSponsor({{ $index }})">
+                            Zuordnung rückgängig
+                        </flux:button>
+                    @endif
                 </div>
 
                 <div class="grid items-start gap-4 sm:grid-cols-2">
-                    <flux:switch wire:model="sponsorRows.{{ $index }}.is_published" label="Veröffentlicht" description="Zeigt die Sponsor:in auf der Startseite." />
+                    <flux:switch
+                        wire:model="sponsorRows.{{ $index }}.is_published"
+                        x-bind:disabled="!$wire.sponsorRows[{{ $index }}].attached"
+                        label="Veröffentlicht"
+                        description="Zeigt die Sponsor:in auf der Startseite."
+                    />
 
                     <flux:field>
                         <div class="flex items-center gap-1">
                             <flux:label badge="Pflichtfeld">Grösse</flux:label>
                             <x-admin.field-info label="Grösse" text="Steuert die Breite des Sponsor:innen-Logos auf der Startseite." />
                         </div>
-                        <flux:select wire:model="sponsorRows.{{ $index }}.size" required>
+                        <flux:select wire:model="sponsorRows.{{ $index }}.size" x-bind:disabled="!$wire.sponsorRows[{{ $index }}].attached" required>
                             <flux:select.option value="small">Klein</flux:select.option>
                             <flux:select.option value="medium">Mittel</flux:select.option>
                             <flux:select.option value="large">Gross</flux:select.option>
@@ -79,7 +85,14 @@
                             <flux:label badge="Pflichtfeld">Reihenfolge</flux:label>
                             <x-admin.field-info label="Reihenfolge" text="Kleinere Zahlen erscheinen zuerst. Bei gleicher Zahl wird nach Name sortiert." />
                         </div>
-                        <flux:input type="number" min="0" step="1" wire:model="sponsorRows.{{ $index }}.sort_order" required />
+                        <flux:input
+                            type="number"
+                            min="0"
+                            step="1"
+                            wire:model="sponsorRows.{{ $index }}.sort_order"
+                            x-bind:disabled="!$wire.sponsorRows[{{ $index }}].attached"
+                            required
+                        />
                         <flux:error name="sponsorRows.{{ $index }}.sort_order" />
                     </flux:field>
 
@@ -88,7 +101,13 @@
                             <flux:label badge="Pflichtfeld bei Zuordnung">Beitrag an diesem Anlass</flux:label>
                             <x-admin.field-info label="Beitrag an diesem Anlass" text="Erscheint im Detailfenster der Sponsor:innen-Karte auf der Startseite." />
                         </div>
-                        <flux:textarea rows="3" wire:model="sponsorRows.{{ $index }}.contribution_text" placeholder="Unterstützt die Verpflegung der Teilnehmenden." required />
+                        <flux:textarea
+                            rows="3"
+                            wire:model="sponsorRows.{{ $index }}.contribution_text"
+                            x-bind:disabled="!$wire.sponsorRows[{{ $index }}].attached"
+                            placeholder="Unterstützt die Verpflegung der Teilnehmenden."
+                            required
+                        />
                         <flux:error name="sponsorRows.{{ $index }}.contribution_text" />
                     </flux:field>
                 </div>

--- a/resources/views/components/admin-donation-event-sponsors-form.blade.php
+++ b/resources/views/components/admin-donation-event-sponsors-form.blade.php
@@ -1,0 +1,94 @@
+<form wire:submit="save" class="space-y-6">
+    <flux:card class="space-y-6">
+        <div class="space-y-2">
+            <flux:heading size="lg">Sponsor:innen zuordnen</flux:heading>
+            <flux:subheading>Darstellung und Anlassbeitrag werden pro Anlass festgelegt.</flux:subheading>
+        </div>
+
+        <flux:callout icon="information-circle">
+            Veröffentlichte Sponsor:innen erscheinen auf der Startseite. Beschreibung, Logo und Website werden in der Sponsor:innen-Verwaltung gepflegt; Anlassbeitrag, Grösse und Reihenfolge hier.
+        </flux:callout>
+
+        @forelse ($sponsorRows as $index => $sponsorRow)
+            <div wire:key="event-sponsor-{{ $sponsorRow['id'] }}" class="grid gap-4 border-t border-zinc-200 pt-5 dark:border-zinc-700 lg:grid-cols-[minmax(12rem,1fr)_2fr]">
+                <flux:heading>{{ $sponsorRow['name'] }}</flux:heading>
+
+                <div class="grid items-start gap-4 sm:grid-cols-2">
+                    <flux:switch
+                        wire:model.live="sponsorRows.{{ $index }}.attached"
+                        label="Zugeordnet"
+                        description="Verknüpft diese Sponsor:in mit dem Anlass."
+                    />
+
+                    <flux:switch
+                        wire:model="sponsorRows.{{ $index }}.is_published"
+                        label="Veröffentlicht"
+                        description="Zeigt die Sponsor:in auf der Startseite."
+                        :disabled="! $sponsorRow['attached']"
+                    />
+
+                    <flux:field>
+                        <div class="flex items-center gap-1">
+                            <flux:label>Grösse</flux:label>
+                            <x-admin.field-info label="Grösse" text="Steuert die Breite des Sponsor:innen-Logos auf der Startseite." />
+                        </div>
+                        <flux:select wire:model="sponsorRows.{{ $index }}.size" :disabled="! $sponsorRow['attached']">
+                            <flux:select.option value="small">Klein</flux:select.option>
+                            <flux:select.option value="medium">Mittel</flux:select.option>
+                            <flux:select.option value="large">Gross</flux:select.option>
+                        </flux:select>
+                        <flux:error name="sponsorRows.{{ $index }}.size" />
+                    </flux:field>
+
+                    <flux:field>
+                        <div class="flex items-center gap-1">
+                            <flux:label>Reihenfolge</flux:label>
+                            <x-admin.field-info label="Reihenfolge" text="Kleinere Zahlen erscheinen zuerst. Bei gleicher Zahl wird nach Name sortiert." />
+                        </div>
+                        <flux:input
+                            type="number"
+                            min="0"
+                            step="1"
+                            wire:model="sponsorRows.{{ $index }}.sort_order"
+                            :disabled="! $sponsorRow['attached']"
+                        />
+                        <flux:error name="sponsorRows.{{ $index }}.sort_order" />
+                    </flux:field>
+
+                    <flux:field class="sm:col-span-2">
+                        <div class="flex items-center gap-1">
+                            <flux:label>Beitrag an diesem Anlass</flux:label>
+                            <x-admin.field-info label="Beitrag an diesem Anlass" text="Erscheint im Detailfenster der Sponsor:innen-Karte auf der Startseite und beschreibt die konkrete Unterstützung dieses Anlasses." />
+                        </div>
+                        <flux:textarea
+                            rows="3"
+                            wire:model="sponsorRows.{{ $index }}.contribution_text"
+                            :disabled="! $sponsorRow['attached']"
+                        />
+                        <flux:error name="sponsorRows.{{ $index }}.contribution_text" />
+                    </flux:field>
+                </div>
+
+                <flux:error name="sponsorRows.{{ $index }}.id" />
+                <flux:error name="sponsorRows.{{ $index }}.attached" />
+                <flux:error name="sponsorRows.{{ $index }}.is_published" />
+            </div>
+        @empty
+            <flux:callout icon="user-group" heading="Keine Sponsor:innen vorhanden">
+                <flux:callout.text>
+                    Erfasse zuerst Sponsor:innen in der Sponsor:innen-Verwaltung.
+                    <flux:callout.link href="{{ route('admin.sponsors.index') }}" wire:navigate.hover>Sponsor:innen verwalten</flux:callout.link>
+                </flux:callout.text>
+            </flux:callout>
+        @endforelse
+    </flux:card>
+
+    <div class="flex items-center gap-3">
+        <flux:text wire:dirty class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+        <flux:spacer />
+        <flux:button type="submit" variant="primary" wire:target="save" wire:loading.attr="disabled">
+            <span wire:loading.remove wire:target="save">Sponsor:innen speichern</span>
+            <span wire:loading wire:target="save">Speichert...</span>
+        </flux:button>
+    </div>
+</form>

--- a/resources/views/components/admin-donation-event-sponsors-form.blade.php
+++ b/resources/views/components/admin-donation-event-sponsors-form.blade.php
@@ -1,38 +1,72 @@
-<form wire:submit="save" class="space-y-6">
+<form
+    wire:submit="save"
+    class="space-y-6"
+    data-admin-unsaved-form
+    x-bind:data-unsaved="($wire.$dirty() || $wire.hasUnsavedChanges) ? 'true' : 'false'"
+>
+    @if ($errors->any())
+        <flux:callout
+            variant="danger"
+            icon="exclamation-triangle"
+            heading="Bitte überprüfe die Sponsor:innen"
+            tabindex="-1"
+            x-init="$nextTick(() => { const field = $el.parentElement.querySelector('[aria-invalid=true]'); (field ?? $el).scrollIntoView({ behavior: 'smooth', block: 'center' }); (field ?? $el).focus(); })"
+        >
+            <ul class="list-disc space-y-1 pl-5">
+                @foreach ($errors->all() as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </ul>
+        </flux:callout>
+    @endif
+
+    @php
+        $assignedSponsorRows = collect($sponsorRows)->filter(fn (array $row): bool => $row['attached'] || $row['was_attached']);
+        $availableSponsorRows = collect($sponsorRows)->filter(fn (array $row): bool => ! $row['attached'] && ! $row['was_attached']);
+    @endphp
+
     <flux:card class="space-y-6">
         <div class="space-y-2">
-            <flux:heading size="lg">Sponsor:innen zuordnen</flux:heading>
+            <flux:heading size="lg">Zugeordnete Sponsor:innen</flux:heading>
             <flux:subheading>Darstellung und Anlassbeitrag werden pro Anlass festgelegt.</flux:subheading>
         </div>
 
         <flux:callout icon="information-circle">
-            Veröffentlichte Sponsor:innen erscheinen auf der Startseite. Beschreibung, Logo und Website werden in der Sponsor:innen-Verwaltung gepflegt; Anlassbeitrag, Grösse und Reihenfolge hier.
+            Veröffentlichte Sponsor:innen erscheinen auf der Startseite. Anlassbeitrag, Grösse und Reihenfolge gelten nur für diesen Anlass.
         </flux:callout>
 
-        @forelse ($sponsorRows as $index => $sponsorRow)
-            <div wire:key="event-sponsor-{{ $sponsorRow['id'] }}" class="grid gap-4 border-t border-zinc-200 pt-5 dark:border-zinc-700 lg:grid-cols-[minmax(12rem,1fr)_2fr]">
-                <flux:heading>{{ $sponsorRow['name'] }}</flux:heading>
+        @forelse ($assignedSponsorRows as $index => $sponsorRow)
+            <div wire:key="event-sponsor-assigned-{{ $sponsorRow['id'] }}" class="grid gap-4 border-t border-zinc-200 pt-5 dark:border-zinc-700 lg:grid-cols-[minmax(12rem,1fr)_2fr]">
+                <div class="space-y-3">
+                    <flux:heading>{{ $sponsorRow['name'] }}</flux:heading>
+
+                    @if ($sponsorRow['was_attached'])
+                        <flux:switch
+                            wire:model="sponsorRows.{{ $index }}.attached"
+                            label="Zugeordnet"
+                            description="Ausschalten, um die Sponsor:in beim Speichern zu entfernen."
+                        />
+                        <flux:callout
+                            x-cloak
+                            x-show="!$wire.sponsorRows[{{ $index }}].attached"
+                            variant="warning"
+                            icon="exclamation-triangle"
+                            heading="Vom Anlass entfernen"
+                        >
+                            Beim Speichern gehen Grösse, Anlassbeitrag, Reihenfolge und Veröffentlichungsstatus verloren.
+                        </flux:callout>
+                    @endif
+                </div>
 
                 <div class="grid items-start gap-4 sm:grid-cols-2">
-                    <flux:switch
-                        wire:model.live="sponsorRows.{{ $index }}.attached"
-                        label="Zugeordnet"
-                        description="Verknüpft diese Sponsor:in mit dem Anlass."
-                    />
-
-                    <flux:switch
-                        wire:model="sponsorRows.{{ $index }}.is_published"
-                        label="Veröffentlicht"
-                        description="Zeigt die Sponsor:in auf der Startseite."
-                        :disabled="! $sponsorRow['attached']"
-                    />
+                    <flux:switch wire:model="sponsorRows.{{ $index }}.is_published" label="Veröffentlicht" description="Zeigt die Sponsor:in auf der Startseite." />
 
                     <flux:field>
                         <div class="flex items-center gap-1">
-                            <flux:label>Grösse</flux:label>
+                            <flux:label badge="Pflichtfeld">Grösse</flux:label>
                             <x-admin.field-info label="Grösse" text="Steuert die Breite des Sponsor:innen-Logos auf der Startseite." />
                         </div>
-                        <flux:select wire:model="sponsorRows.{{ $index }}.size" :disabled="! $sponsorRow['attached']">
+                        <flux:select wire:model="sponsorRows.{{ $index }}.size" required>
                             <flux:select.option value="small">Klein</flux:select.option>
                             <flux:select.option value="medium">Mittel</flux:select.option>
                             <flux:select.option value="large">Gross</flux:select.option>
@@ -42,29 +76,19 @@
 
                     <flux:field>
                         <div class="flex items-center gap-1">
-                            <flux:label>Reihenfolge</flux:label>
+                            <flux:label badge="Pflichtfeld">Reihenfolge</flux:label>
                             <x-admin.field-info label="Reihenfolge" text="Kleinere Zahlen erscheinen zuerst. Bei gleicher Zahl wird nach Name sortiert." />
                         </div>
-                        <flux:input
-                            type="number"
-                            min="0"
-                            step="1"
-                            wire:model="sponsorRows.{{ $index }}.sort_order"
-                            :disabled="! $sponsorRow['attached']"
-                        />
+                        <flux:input type="number" min="0" step="1" wire:model="sponsorRows.{{ $index }}.sort_order" required />
                         <flux:error name="sponsorRows.{{ $index }}.sort_order" />
                     </flux:field>
 
                     <flux:field class="sm:col-span-2">
                         <div class="flex items-center gap-1">
-                            <flux:label>Beitrag an diesem Anlass</flux:label>
-                            <x-admin.field-info label="Beitrag an diesem Anlass" text="Erscheint im Detailfenster der Sponsor:innen-Karte auf der Startseite und beschreibt die konkrete Unterstützung dieses Anlasses." />
+                            <flux:label badge="Pflichtfeld bei Zuordnung">Beitrag an diesem Anlass</flux:label>
+                            <x-admin.field-info label="Beitrag an diesem Anlass" text="Erscheint im Detailfenster der Sponsor:innen-Karte auf der Startseite." />
                         </div>
-                        <flux:textarea
-                            rows="3"
-                            wire:model="sponsorRows.{{ $index }}.contribution_text"
-                            :disabled="! $sponsorRow['attached']"
-                        />
+                        <flux:textarea rows="3" wire:model="sponsorRows.{{ $index }}.contribution_text" placeholder="Unterstützt die Verpflegung der Teilnehmenden." required />
                         <flux:error name="sponsorRows.{{ $index }}.contribution_text" />
                     </flux:field>
                 </div>
@@ -74,17 +98,46 @@
                 <flux:error name="sponsorRows.{{ $index }}.is_published" />
             </div>
         @empty
-            <flux:callout icon="user-group" heading="Keine Sponsor:innen vorhanden">
-                <flux:callout.text>
-                    Erfasse zuerst Sponsor:innen in der Sponsor:innen-Verwaltung.
-                    <flux:callout.link href="{{ route('admin.sponsors.index') }}" wire:navigate.hover>Sponsor:innen verwalten</flux:callout.link>
-                </flux:callout.text>
-            </flux:callout>
+            <flux:text>Noch keine Sponsor:innen zugeordnet.</flux:text>
         @endforelse
     </flux:card>
 
-    <div class="flex items-center gap-3">
-        <flux:text wire:dirty class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+    <flux:card class="space-y-4">
+        <div>
+            <flux:heading size="lg">Verfügbare Sponsor:innen</flux:heading>
+            <flux:subheading>Neue Zuordnungen sind zunächst nicht veröffentlicht.</flux:subheading>
+        </div>
+
+        @forelse ($availableSponsorRows as $index => $sponsorRow)
+            <div wire:key="event-sponsor-available-{{ $sponsorRow['id'] }}" class="flex flex-wrap items-center gap-3 border-t border-zinc-200 pt-4 dark:border-zinc-700">
+                <flux:text class="font-medium">{{ $sponsorRow['name'] }}</flux:text>
+                <flux:spacer />
+                <flux:button type="button" size="sm" variant="primary" wire:click="attachSponsor({{ $index }})">Zuordnen</flux:button>
+            </div>
+        @empty
+            @if ($sponsorRows === [])
+                <flux:callout icon="user-group" heading="Keine Sponsor:innen vorhanden">
+                    <flux:callout.text>
+                        Erfasse zuerst Sponsor:innen in der Sponsor:innen-Verwaltung.
+                        <flux:callout.link href="{{ route('admin.sponsors.index') }}" wire:navigate.hover>Sponsor:innen verwalten</flux:callout.link>
+                    </flux:callout.text>
+                </flux:callout>
+            @else
+                <flux:text>Alle Sponsor:innen sind zugeordnet.</flux:text>
+            @endif
+        @endforelse
+    </flux:card>
+
+    <div class="sticky bottom-0 z-20 flex items-center gap-3 border-t border-zinc-200 bg-white/95 px-4 py-3 shadow-lg backdrop-blur dark:border-zinc-700 dark:bg-zinc-900/95">
+        <div x-cloak x-show="$wire.$dirty() || $wire.hasUnsavedChanges" class="space-y-1.5">
+            <flux:text class="text-sm text-accent">Ungespeicherte Änderungen</flux:text>
+            <div class="flex flex-wrap gap-1.5">
+                @foreach ($sponsorRows as $index => $sponsorRow)
+                    <flux:badge size="sm" x-cloak x-show="$wire.$dirty('sponsorRows.{{ $index }}')">{{ $sponsorRow['name'] }}</flux:badge>
+                @endforeach
+                <flux:badge size="sm" x-cloak x-show="$wire.hasUnsavedChanges && !$wire.$dirty()">Zuordnungen</flux:badge>
+            </div>
+        </div>
         <flux:spacer />
         <flux:button type="submit" variant="primary" wire:target="save" wire:loading.attr="disabled">
             <span wire:loading.remove wire:target="save">Sponsor:innen speichern</span>

--- a/resources/views/components/admin/field-info.blade.php
+++ b/resources/views/components/admin/field-info.blade.php
@@ -1,5 +1,5 @@
 @props(['label', 'text'])
 
 <flux:tooltip :content="$text" toggleable>
-    <flux:button type="button" size="xs" variant="ghost" icon="information-circle" square aria-label="Hinweis zu {{ $label }}" />
+    <flux:button type="button" size="xs" variant="ghost" icon="information-circle" icon:variant="outline" square aria-label="Hinweis zu {{ $label }}" />
 </flux:tooltip>

--- a/resources/views/components/admin/settings.blade.php
+++ b/resources/views/components/admin/settings.blade.php
@@ -1,4 +1,4 @@
-<div class="space-y-8" data-admin-settings-root>
+<div class="space-y-8">
     <flux:tab.group>
         <flux:tabs wire:model="activeTab" scrollable scrollable:fade>
             <flux:tab name="overview" icon="home">Übersicht</flux:tab>
@@ -136,7 +136,6 @@
                                 wire:click="saveClass('{{ $classParam }}')"
                                 wire:key="save-class-{{ md5($fqcn) }}"
                                 wire:target="{{ $classTargets }}"
-                                data-admin-settings-save-class-button
                                 wire:dirty.remove.attr="disabled"
                                 disabled
                             >

--- a/resources/views/components/admin/tables/donation-event-table.blade.php
+++ b/resources/views/components/admin/tables/donation-event-table.blade.php
@@ -12,6 +12,9 @@
 
                 <x-slot:bottomLeft>
                     <div class="flex flex-wrap items-center gap-2">
+                        <flux:button as="a" href="{{ route('admin.donation-events.create') }}" variant="ghost" size="sm" icon="plus" wire:navigate.hover>
+                            Neu
+                        </flux:button>
                         <x-datatable.export-dropdown />
                         <x-datatable.column-visibility-dropdown :column-options="$this->visibleColumnOptions()" />
                     </div>
@@ -39,6 +42,7 @@
                             @endif
                         </flux:table.column>
                     @endforeach
+                    <flux:table.column class="w-1 whitespace-nowrap text-right">Aktion</flux:table.column>
                 </flux:table.columns>
 
                 <flux:table.rows>
@@ -122,6 +126,20 @@
                                     @endswitch
                                 </flux:table.cell>
                             @endforeach
+                            <flux:table.cell class="w-1 whitespace-nowrap">
+                                <div class="flex justify-end">
+                                    <flux:button
+                                        as="a"
+                                        href="{{ route('admin.donation-events.edit', $donationEvent) }}"
+                                        size="xs"
+                                        variant="ghost"
+                                        icon="pencil-square"
+                                        square
+                                        tooltip="Bearbeiten"
+                                        wire:navigate.hover
+                                    />
+                                </div>
+                            </flux:table.cell>
                         </flux:table.row>
                     @empty
                         <flux:table.row wire:loading.remove wire:target="{{ $this->tableLoadingTargets() }}">

--- a/resources/views/components/home-hero.blade.php
+++ b/resources/views/components/home-hero.blade.php
@@ -36,7 +36,7 @@
   </x-slot:kicker>
 
   <x-slot:title>
-    Höhenmeter für&nbsp;Menschen
+    {{ $currentDonationEvent?->title ?? 'Höhenmeter für Menschen' }}
   </x-slot:title>
 
   <x-slot:copy>
@@ -77,4 +77,3 @@
     @endif
   </x-slot:partners>
 </x-hero>
-

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -18,7 +18,7 @@
                 'label' => 'Anlässe',
                 'route' => 'admin.donation-events.index',
                 'svg' => '<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-6"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V8.25A2.25 2.25 0 0 1 5.25 6h13.5A2.25 2.25 0 0 1 21 8.25v10.5M3 18.75A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75M3 18.75v-6.75A2.25 2.25 0 0 1 5.25 9.75h13.5A2.25 2.25 0 0 1 21 12v6.75" /></svg>',
-                'current' => $thisRoute === 'admin.donation-events.index',
+                'current' => str_starts_with((string) $thisRoute, 'admin.donation-events.'),
             ],
             [
                 'label' => 'Partner:innen',

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -213,7 +213,7 @@
                 </button>
             </div>
 
-            <main class="min-w-0 overflow-x-hidden py-10">
+            <main class="min-w-0 overflow-x-clip py-10">
                 <div class="min-w-0 px-4 sm:px-6 lg:px-8">
                     <x-admin.page-title>{{ $title }}</x-admin.page-title>
 

--- a/resources/views/layouts/base.blade.php
+++ b/resources/views/layouts/base.blade.php
@@ -12,7 +12,7 @@
 
     <!-- SEO Information -->
     <meta name="description"
-          content="{{ $currentDonationEvent?->contentPlainText('seo.meta_description_md', 'Höhenmeter für Menschen: Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen.') ?? 'Höhenmeter für Menschen: Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen.' }}">
+          content="{{ $currentDonationEvent?->contentPlainText('seo.meta_description_md', 'Höhenmeter für Menschen: Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen.') ?: 'Höhenmeter für Menschen: Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen.' }}">
     <meta name="keywords"
           content="Höhenmeter für Menschen, fundraising, charity event, Wohltätigkeit, Winterthur, sponsored run, Sponsorenlauf, Spendenlauf, Brühlgut Stiftung, Institut Kinderseele Schweiz, Tel 143, Dargebotene Hand, Roundtable, Round Table">
     <meta name="author" content="Round Table 25 Winterthur">
@@ -32,7 +32,7 @@
     <meta name="apple-mobile-web-app-title" content="Höhenmeter für Menschen">
     <meta name="og:title" content="Höhenmeter für Menschen">
     <meta name="og:description"
-          content="{{ $currentDonationEvent?->contentPlainText('seo.og_description_md', 'Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen.') ?? 'Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen.' }}">
+          content="{{ $currentDonationEvent?->contentPlainText('seo.og_description_md', 'Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen.') ?: 'Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen.' }}">
     <meta name="og:image" content="{{ Vite::asset("resources/images/logo_light.svg") }}">
     <meta name="og:url" content="https://hfm-winti.ch">
     <meta name="og:type" content="website">

--- a/resources/views/pages/admin/donation-event-settings.blade.php
+++ b/resources/views/pages/admin/donation-event-settings.blade.php
@@ -1,0 +1,24 @@
+@php($donationEvent = $donationEvent ?? null)
+
+@component('layouts.admin', ['title' => $donationEvent === null ? 'Anlass erstellen' : 'Anlass bearbeiten'])
+    @section('content')
+        <div class="space-y-6">
+            <div class="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                    @if ($donationEvent !== null)
+                        <flux:heading size="lg">{{ $donationEvent->title }} ({{ $donationEvent->slug }})</flux:heading>
+                        <flux:subheading>Anlassdaten und öffentliche Inhalte verwalten.</flux:subheading>
+                    @else
+                        <flux:subheading>Nach dem Erstellen können Partner:innen und Sponsor:innen zugeordnet werden.</flux:subheading>
+                    @endif
+                </div>
+
+                <flux:button as="a" href="{{ route('admin.donation-events.index') }}" variant="ghost" icon="arrow-left" wire:navigate.hover>
+                    Zur Übersicht
+                </flux:button>
+            </div>
+
+            @livewire('admin-donation-event-form', ['donationEvent' => $donationEvent])
+        </div>
+    @endsection
+@endcomponent

--- a/resources/views/pages/admin/donation-event-settings.blade.php
+++ b/resources/views/pages/admin/donation-event-settings.blade.php
@@ -18,7 +18,24 @@
                 </flux:button>
             </div>
 
-            @livewire('admin-donation-event-form', ['donationEvent' => $donationEvent])
+            @if ($donationEvent === null)
+                @livewire('admin-donation-event-form')
+            @else
+                <flux:tab.group>
+                    <flux:tabs scrollable scrollable:fade>
+                        <flux:tab name="event">Anlass</flux:tab>
+                        <flux:tab name="partners">Partner:innen</flux:tab>
+                    </flux:tabs>
+
+                    <flux:tab.panel name="event" class="pt-6">
+                        @livewire('admin-donation-event-form', ['donationEvent' => $donationEvent])
+                    </flux:tab.panel>
+
+                    <flux:tab.panel name="partners" class="pt-6">
+                        @livewire('admin-donation-event-partners-form', ['donationEvent' => $donationEvent])
+                    </flux:tab.panel>
+                </flux:tab.group>
+            @endif
         </div>
     @endsection
 @endcomponent

--- a/resources/views/pages/admin/donation-event-settings.blade.php
+++ b/resources/views/pages/admin/donation-event-settings.blade.php
@@ -25,6 +25,7 @@
                     <flux:tabs scrollable scrollable:fade>
                         <flux:tab name="event">Anlass</flux:tab>
                         <flux:tab name="partners">Partner:innen</flux:tab>
+                        <flux:tab name="sponsors">Sponsor:innen</flux:tab>
                     </flux:tabs>
 
                     <flux:tab.panel name="event" class="pt-6">
@@ -33,6 +34,10 @@
 
                     <flux:tab.panel name="partners" class="pt-6">
                         @livewire('admin-donation-event-partners-form', ['donationEvent' => $donationEvent])
+                    </flux:tab.panel>
+
+                    <flux:tab.panel name="sponsors" class="pt-6">
+                        @livewire('admin-donation-event-sponsors-form', ['donationEvent' => $donationEvent])
                     </flux:tab.panel>
                 </flux:tab.group>
             @endif

--- a/resources/views/pages/admin/donation-event-settings.blade.php
+++ b/resources/views/pages/admin/donation-event-settings.blade.php
@@ -4,10 +4,18 @@
     @section('content')
         <div class="space-y-6">
             <div class="flex flex-wrap items-center justify-between gap-3">
-                <div>
+                <div class="space-y-2">
                     @if ($donationEvent !== null)
                         <flux:heading size="lg">{{ $donationEvent->title }} ({{ $donationEvent->slug }})</flux:heading>
                         <flux:subheading>Anlassdaten und öffentliche Inhalte verwalten.</flux:subheading>
+                        <div class="flex flex-wrap gap-2">
+                            @if ($isCurrentEvent ?? false)
+                                <flux:badge color="blue" icon="star">Aktueller Anlass</flux:badge>
+                            @endif
+                            <flux:badge :color="$donationEvent->is_published ? 'green' : 'zinc'" :icon="$donationEvent->is_published ? 'globe-alt' : 'pencil-square'">
+                                {{ $donationEvent->is_published ? 'Veröffentlicht' : 'Entwurf' }}
+                            </flux:badge>
+                        </div>
                     @else
                         <flux:subheading>Nach dem Erstellen können Partner:innen und Sponsor:innen zugeordnet werden.</flux:subheading>
                     @endif
@@ -29,7 +37,7 @@
                     </flux:tabs>
 
                     <flux:tab.panel name="event" class="pt-6">
-                        @livewire('admin-donation-event-form', ['donationEvent' => $donationEvent])
+                        @livewire('admin-donation-event-form', ['donationEvent' => $donationEvent, 'isCurrentEvent' => $isCurrentEvent ?? false])
                     </flux:tab.panel>
 
                     <flux:tab.panel name="partners" class="pt-6">

--- a/resources/views/pages/results.blade.php
+++ b/resources/views/pages/results.blade.php
@@ -2,7 +2,7 @@
 
 @section('content')
     @component('components.page-title')
-        {{ $currentDonationEvent?->contentPlainText('results.heading_md', 'Resultate') ?? 'Resultate' }}
+        {{ $currentDonationEvent?->contentPlainText('results.heading_md', 'Resultate') ?: 'Resultate' }}
     @endcomponent
 
     <div class="w-full max-w-2xl mx-auto text-left sm:text-center my-12">

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Admin\DonationEventSettingsController;
 use App\Http\Controllers\Admin\WeblingInterfaceTestPdfController;
 use App\Http\Controllers\AdminSessionController;
 use Illuminate\Support\Facades\Route;
@@ -7,6 +8,8 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('auth:web')->group(function (): void {
     Route::view('admin', 'pages.admin.dashboard')->name('admin.dashboard');
     Route::view('admin/anlaesse', 'pages.admin.donation-events')->name('admin.donation-events.index');
+    Route::get('admin/anlaesse/neu', [DonationEventSettingsController::class, 'create'])->name('admin.donation-events.create');
+    Route::get('admin/anlaesse/{donationEvent}/bearbeiten', [DonationEventSettingsController::class, 'edit'])->name('admin.donation-events.edit');
     Route::view('admin/partner', 'pages.admin.partners')->name('admin.partners.index');
     Route::view('admin/sponsoren', 'pages.admin.sponsors')->name('admin.sponsors.index');
     Route::view('admin/faqs', 'pages.admin.faqs')->name('admin.faqs.index');

--- a/tests/Feature/AdminDonationEventPartnersTest.php
+++ b/tests/Feature/AdminDonationEventPartnersTest.php
@@ -1,0 +1,184 @@
+<?php
+
+use App\Actions\SyncDonationEventPartnersAction;
+use App\Components\AdminDonationEventPartnersForm;
+use App\Models\AthleteRegistration;
+use App\Models\DonationEvent;
+use App\Models\Partner;
+use App\Models\User;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\get;
+
+it('shows event and partner tabs on the edit page', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    get(route('admin.donation-events.edit', $donationEvent))
+        ->assertSuccessful()
+        ->assertSee('Anlass')
+        ->assertSee('Partner:innen')
+        ->assertSee('Partner:innen zuordnen');
+});
+
+it('loads assignments and locks partners referenced by registrations', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $assignedPartner = Partner::factory()->create(['name' => 'Alpha Partner']);
+    $referencedPartner = Partner::factory()->create(['name' => 'Beta Partner']);
+
+    $donationEvent->partners()->attach($assignedPartner, [
+        'sort_order' => 20,
+        'is_published' => false,
+    ]);
+    AthleteRegistration::factory()
+        ->forEvent($donationEvent)
+        ->withPartner($referencedPartner)
+        ->create();
+
+    Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => $donationEvent])
+        ->assertSet('partnerRows.0.name', 'Alpha Partner')
+        ->assertSet('partnerRows.0.attached', true)
+        ->assertSet('partnerRows.0.sort_order', 20)
+        ->assertSet('partnerRows.0.is_published', false)
+        ->assertSet('partnerRows.0.is_locked', false)
+        ->assertSet('partnerRows.1.name', 'Beta Partner')
+        ->assertSet('partnerRows.1.attached', true)
+        ->assertSet('partnerRows.1.is_locked', true)
+        ->assertSet('partnerRows.1.registration_count', 1);
+});
+
+it('attaches updates and detaches unreferenced partners', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $detachedPartner = Partner::factory()->create(['name' => 'Alpha Partner']);
+    $attachedPartner = Partner::factory()->create(['name' => 'Beta Partner']);
+
+    $donationEvent->partners()->attach($detachedPartner, [
+        'sort_order' => 10,
+        'is_published' => true,
+    ]);
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => $donationEvent])
+        ->set('partnerRows.0.attached', false)
+        ->set('partnerRows.1.attached', true)
+        ->set('partnerRows.1.sort_order', 5)
+        ->set('partnerRows.1.is_published', false)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    assertDatabaseMissing('donation_event_partner', [
+        'donation_event_id' => $donationEvent->id,
+        'partner_id' => $detachedPartner->id,
+    ]);
+    assertDatabaseHas('donation_event_partner', [
+        'donation_event_id' => $donationEvent->id,
+        'partner_id' => $attachedPartner->id,
+        'sort_order' => 5,
+        'is_published' => false,
+    ]);
+});
+
+it('keeps referenced partners attached when submitted as detached', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $partner = Partner::factory()->create();
+    $donationEvent->partners()->attach($partner, [
+        'sort_order' => 10,
+        'is_published' => true,
+    ]);
+    AthleteRegistration::factory()
+        ->forEvent($donationEvent)
+        ->withPartner($partner)
+        ->create();
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => $donationEvent])
+        ->set('partnerRows.0.attached', false)
+        ->set('partnerRows.0.sort_order', 30)
+        ->set('partnerRows.0.is_published', false)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSet('partnerRows.0.attached', true)
+        ->assertSet('partnerRows.0.is_locked', true);
+
+    assertDatabaseHas('donation_event_partner', [
+        'donation_event_id' => $donationEvent->id,
+        'partner_id' => $partner->id,
+        'sort_order' => 30,
+        'is_published' => false,
+    ]);
+});
+
+it('attaches partners referenced by legacy registrations without a pivot', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $partner = Partner::factory()->create();
+    AthleteRegistration::factory()
+        ->forEvent($donationEvent)
+        ->withPartner($partner)
+        ->create();
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => $donationEvent])
+        ->assertSet('partnerRows.0.attached', true)
+        ->assertSet('partnerRows.0.is_locked', true)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    assertDatabaseHas('donation_event_partner', [
+        'donation_event_id' => $donationEvent->id,
+        'partner_id' => $partner->id,
+        'is_published' => true,
+    ]);
+});
+
+it('retains referenced partners omitted from the action payload', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $partner = Partner::factory()->create();
+    $donationEvent->partners()->attach($partner, [
+        'sort_order' => 40,
+        'is_published' => false,
+    ]);
+    AthleteRegistration::factory()
+        ->forEvent($donationEvent)
+        ->withPartner($partner)
+        ->create();
+
+    app(SyncDonationEventPartnersAction::class)($donationEvent, []);
+
+    assertDatabaseHas('donation_event_partner', [
+        'donation_event_id' => $donationEvent->id,
+        'partner_id' => $partner->id,
+        'sort_order' => 40,
+        'is_published' => false,
+    ]);
+});
+
+it('validates partner rows', function (): void {
+    Partner::factory()->count(2)->create();
+
+    actingAs(User::factory()->create());
+
+    $component = Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => DonationEvent::factory()->create()]);
+    $partnerRows = $component->get('partnerRows');
+
+    $component
+        ->set('partnerRows.1.id', $partnerRows[0]['id'])
+        ->set('partnerRows.0.sort_order', -1)
+        ->call('save')
+        ->assertHasErrors([
+            'partnerRows.0.sort_order' => 'min',
+            'partnerRows.1.id' => 'distinct',
+        ]);
+});
+
+it('rejects unauthenticated partner mutations', function (): void {
+    Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => DonationEvent::factory()->create()])
+        ->call('save')
+        ->assertForbidden();
+});

--- a/tests/Feature/AdminDonationEventPartnersTest.php
+++ b/tests/Feature/AdminDonationEventPartnersTest.php
@@ -22,7 +22,9 @@ it('shows event and partner tabs on the edit page', function (): void {
         ->assertSuccessful()
         ->assertSee('Anlass')
         ->assertSee('Partner:innen')
-        ->assertSee('Partner:innen zuordnen');
+        ->assertSee('Zugeordnete Partner:innen')
+        ->assertSee('Verfügbare Partner:innen')
+        ->assertSee('Zuordnungen');
 });
 
 it('loads assignments and locks partners referenced by registrations', function (): void {
@@ -48,7 +50,8 @@ it('loads assignments and locks partners referenced by registrations', function 
         ->assertSet('partnerRows.1.name', 'Beta Partner')
         ->assertSet('partnerRows.1.attached', true)
         ->assertSet('partnerRows.1.is_locked', true)
-        ->assertSet('partnerRows.1.registration_count', 1);
+        ->assertSet('partnerRows.1.registration_count', 1)
+        ->assertSee('Vom Anlass entfernen');
 });
 
 it('attaches updates and detaches unreferenced partners', function (): void {
@@ -58,7 +61,7 @@ it('attaches updates and detaches unreferenced partners', function (): void {
 
     $donationEvent->partners()->attach($detachedPartner, [
         'sort_order' => 10,
-        'is_published' => true,
+        'is_published' => false,
     ]);
 
     actingAs(User::factory()->create());
@@ -88,7 +91,7 @@ it('keeps referenced partners attached when submitted as detached', function ():
     $partner = Partner::factory()->create();
     $donationEvent->partners()->attach($partner, [
         'sort_order' => 10,
-        'is_published' => true,
+        'is_published' => false,
     ]);
     AthleteRegistration::factory()
         ->forEvent($donationEvent)
@@ -133,7 +136,7 @@ it('attaches partners referenced by legacy registrations without a pivot', funct
     assertDatabaseHas('donation_event_partner', [
         'donation_event_id' => $donationEvent->id,
         'partner_id' => $partner->id,
-        'is_published' => true,
+        'is_published' => false,
     ]);
 });
 
@@ -169,12 +172,41 @@ it('validates partner rows', function (): void {
 
     $component
         ->set('partnerRows.1.id', $partnerRows[0]['id'])
+        ->set('partnerRows.0.attached', true)
         ->set('partnerRows.0.sort_order', -1)
         ->call('save')
         ->assertHasErrors([
             'partnerRows.0.sort_order' => 'min',
             'partnerRows.1.id' => 'distinct',
         ]);
+});
+
+it('ignores invalid pivot data for detached partners', function (): void {
+    Partner::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => DonationEvent::factory()->create()])
+        ->set('partnerRows.0.sort_order', -1)
+        ->call('save')
+        ->assertHasNoErrors();
+});
+
+it('loads assigned partners in public order and available partners alphabetically', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $laterByName = Partner::factory()->create(['name' => 'Zulu Assigned']);
+    $firstByName = Partner::factory()->create(['name' => 'Alpha Assigned']);
+    Partner::factory()->create(['name' => 'Beta Available']);
+    Partner::factory()->create(['name' => 'Alpha Available']);
+
+    $donationEvent->partners()->attach($laterByName, ['sort_order' => 10, 'is_published' => true]);
+    $donationEvent->partners()->attach($firstByName, ['sort_order' => 20, 'is_published' => true]);
+
+    Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => $donationEvent])
+        ->assertSet('partnerRows.0.name', 'Zulu Assigned')
+        ->assertSet('partnerRows.1.name', 'Alpha Assigned')
+        ->assertSet('partnerRows.2.name', 'Alpha Available')
+        ->assertSet('partnerRows.3.name', 'Beta Available');
 });
 
 it('rejects unauthenticated partner mutations', function (): void {

--- a/tests/Feature/AdminDonationEventPartnersTest.php
+++ b/tests/Feature/AdminDonationEventPartnersTest.php
@@ -51,6 +51,7 @@ it('loads assignments and locks partners referenced by registrations', function 
         ->assertSet('partnerRows.1.attached', true)
         ->assertSet('partnerRows.1.is_locked', true)
         ->assertSet('partnerRows.1.registration_count', 1)
+        ->assertSee('x-bind:disabled="!$wire.partnerRows[0].attached"', escape: false)
         ->assertSee('Vom Anlass entfernen');
 });
 
@@ -84,6 +85,20 @@ it('attaches updates and detaches unreferenced partners', function (): void {
         'sort_order' => 5,
         'is_published' => false,
     ]);
+});
+
+it('undoes a new partner assignment before saving', function (): void {
+    Partner::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventPartnersForm::class, ['donationEvent' => DonationEvent::factory()->create()])
+        ->call('attachPartner', 0)
+        ->assertSet('partnerRows.0.attached', true)
+        ->assertSee('Zuordnung rückgängig')
+        ->call('detachPartner', 0)
+        ->assertSet('partnerRows.0.attached', false)
+        ->assertDontSee('Zuordnung rückgängig');
 });
 
 it('keeps referenced partners attached when submitted as detached', function (): void {

--- a/tests/Feature/AdminDonationEventSettingsTest.php
+++ b/tests/Feature/AdminDonationEventSettingsTest.php
@@ -5,6 +5,7 @@ use App\Components\AdminDonationEventTable;
 use App\Models\DonationEvent;
 use App\Models\ExternalUser;
 use App\Models\User;
+use App\Settings\EventSettings;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
@@ -32,7 +33,13 @@ it('renders create and edit settings pages for admins', function (): void {
         ->assertSee('Anlass erstellen')
         ->assertSee('Öffentliche Inhalte')
         ->assertSee('Erscheint als Haupttitel im Hero der Startseite')
-        ->assertSeeInOrder(['Titel', 'Kürzel'])
+        ->assertSeeInOrder(['Titel', 'Slug'])
+        ->assertSeeInOrder(['Startseite', 'Resultate', 'SEO / Teilen', 'Rechnung'])
+        ->assertSee('Leere Anmeldedaten halten die entsprechende Anmeldung geschlossen')
+        ->assertSee('inputmode="numeric"', escape: false)
+        ->assertSee('type="url"', escape: false)
+        ->assertSee('overflow-x-clip', escape: false)
+        ->assertSee('Formularangaben')
         ->assertSee('Markdown-Syntax')
         ->assertDontSee('form.timezone', escape: false);
 
@@ -42,6 +49,43 @@ it('renders create and edit settings pages for admins', function (): void {
         ->assertSee('Änderungen speichern');
 
     get(route('admin.donation-events.edit', 999999))->assertNotFound();
+});
+
+it('shows current and publication status in the page header', function (): void {
+    $donationEvent = DonationEvent::factory()->create(['is_published' => true]);
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $donationEvent->id;
+    $settings->save();
+
+    actingAs(User::factory()->create());
+
+    get(route('admin.donation-events.edit', $donationEvent))
+        ->assertSuccessful()
+        ->assertSee('Aktueller Anlass')
+        ->assertSee('Veröffentlicht');
+});
+
+it('requires confirmation before unpublishing the current event', function (): void {
+    $donationEvent = DonationEvent::factory()->create(['is_published' => true]);
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $donationEvent->id;
+    $settings->save();
+
+    actingAs(User::factory()->create());
+
+    $component = Livewire::test(AdminDonationEventForm::class, [
+        'donationEvent' => $donationEvent,
+        'isCurrentEvent' => true,
+    ])
+        ->set('form.is_published', false)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect($donationEvent->refresh()->is_published)->toBeTrue();
+
+    $component->call('confirmUnpublished')->assertHasNoErrors();
+
+    expect($donationEvent->refresh()->is_published)->toBeFalse();
 });
 
 it('links to event creation and editing from the table', function (): void {

--- a/tests/Feature/AdminDonationEventSettingsTest.php
+++ b/tests/Feature/AdminDonationEventSettingsTest.php
@@ -191,6 +191,18 @@ it('validates event identity, URLs, and date order', function (): void {
         ]);
 });
 
+it('uses readable validation attribute names', function (): void {
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventForm::class)
+        ->set('form', validDonationEventSettingsForm([
+            'location_name' => ['invalid'],
+        ]))
+        ->call('save')
+        ->assertHasErrors(['form.location_name' => 'string'])
+        ->assertSee('Name des Veranstaltungsorts');
+});
+
 it('rejects unauthenticated event mutations', function (): void {
     Livewire::test(AdminDonationEventForm::class)
         ->set('form', validDonationEventSettingsForm())

--- a/tests/Feature/AdminDonationEventSettingsTest.php
+++ b/tests/Feature/AdminDonationEventSettingsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use App\Components\AdminDonationEventForm;
+use App\Components\AdminDonationEventTable;
+use App\Models\DonationEvent;
+use App\Models\ExternalUser;
+use App\Models\User;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+it('protects donation event settings routes', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+
+    get(route('admin.donation-events.create'))->assertRedirect(route('login'));
+    get(route('admin.donation-events.edit', $donationEvent))->assertRedirect(route('login'));
+
+    actingAs(ExternalUser::factory()->create(), 'external');
+
+    get(route('admin.donation-events.create'))->assertRedirect(route('login'));
+    get(route('admin.donation-events.edit', $donationEvent))->assertRedirect(route('login'));
+});
+
+it('renders create and edit settings pages for admins', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    get(route('admin.donation-events.create'))
+        ->assertSuccessful()
+        ->assertSee('Anlass erstellen')
+        ->assertSee('Öffentliche Inhalte')
+        ->assertSee('Erscheint als Haupttitel im Hero der Startseite')
+        ->assertSeeInOrder(['Titel', 'Kürzel'])
+        ->assertSee('Markdown-Syntax')
+        ->assertDontSee('form.timezone', escape: false);
+
+    get(route('admin.donation-events.edit', $donationEvent))
+        ->assertSuccessful()
+        ->assertSee($donationEvent->title)
+        ->assertSee('Änderungen speichern');
+
+    get(route('admin.donation-events.edit', 999999))->assertNotFound();
+});
+
+it('links to event creation and editing from the table', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+
+    Livewire::test(AdminDonationEventTable::class)
+        ->assertSee('Neu')
+        ->assertSee(route('admin.donation-events.create'), escape: false)
+        ->assertSee(route('admin.donation-events.edit', $donationEvent), escape: false);
+});
+
+it('creates an event and redirects to its settings page', function (): void {
+    actingAs(User::factory()->create());
+
+    $component = Livewire::test(AdminDonationEventForm::class)
+        ->set('form', validDonationEventSettingsForm())
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $donationEvent = DonationEvent::query()->where('slug', '2027')->firstOrFail();
+
+    $component->assertRedirect(route('admin.donation-events.edit', $donationEvent));
+
+    expect($donationEvent->getRawOriginal('starts_at'))->toBe('2027-09-11 11:00:05')
+        ->and($donationEvent->timezone)->toBe('Europe/Zurich')
+        ->and($donationEvent->is_published)->toBeFalse()
+        ->and($donationEvent->has_equal_split_option)->toBeTrue()
+        ->and(data_get($donationEvent->content, 'hero.copy_md'))->toBe('Hero 2027')
+        ->and(data_get($donationEvent->content, 'invoice.additional_information'))->toBe('Rechnung 2027');
+
+    Livewire::test(AdminDonationEventForm::class, ['donationEvent' => $donationEvent])
+        ->assertSet('form.starts_at', '2027-09-11T13:00:05');
+});
+
+it('updates event data while preserving unknown content', function (): void {
+    $donationEvent = DonationEvent::factory()->create([
+        'slug' => '2026',
+        'timezone' => 'UTC',
+        'content' => [
+            'hero' => ['copy_md' => 'Alt'],
+            'future' => ['untouched' => 'Wert'],
+        ],
+    ]);
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventForm::class, ['donationEvent' => $donationEvent])
+        ->set('form', validDonationEventSettingsForm([
+            'slug' => '2028',
+            'title' => 'Neuer Titel',
+            'is_published' => true,
+        ]))
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $donationEvent->refresh();
+
+    expect($donationEvent->slug)->toBe('2028')
+        ->and($donationEvent->title)->toBe('Neuer Titel')
+        ->and($donationEvent->timezone)->toBe('Europe/Zurich')
+        ->and($donationEvent->is_published)->toBeTrue()
+        ->and(data_get($donationEvent->content, 'hero.copy_md'))->toBe('Hero 2027')
+        ->and(data_get($donationEvent->content, 'future.untouched'))->toBe('Wert');
+});
+
+it('allows an event without a registration schedule', function (): void {
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventForm::class)
+        ->set('form', validDonationEventSettingsForm([
+            'registration_opens_at' => '',
+            'athlete_registration_closes_at' => '',
+            'donor_registration_closes_at' => '',
+        ]))
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $donationEvent = DonationEvent::query()->where('slug', '2027')->firstOrFail();
+
+    expect($donationEvent->registration_opens_at)->toBeNull()
+        ->and($donationEvent->athlete_registration_closes_at)->toBeNull()
+        ->and($donationEvent->donor_registration_closes_at)->toBeNull();
+});
+
+it('validates event identity, URLs, and date order', function (): void {
+    DonationEvent::factory()->create(['slug' => 'duplicate']);
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventForm::class)
+        ->set('form', validDonationEventSettingsForm([
+            'slug' => 'duplicate',
+            'ends_at' => '2027-09-11T12:00:05',
+            'athlete_registration_closes_at' => '2027-01-31T23:59:59',
+            'location_url' => 'not-a-url',
+        ]))
+        ->call('save')
+        ->assertHasErrors([
+            'form.slug' => 'unique',
+            'form.ends_at' => 'after',
+            'form.athlete_registration_closes_at' => 'after_or_equal',
+            'form.location_url' => 'url',
+        ]);
+});
+
+it('rejects unauthenticated event mutations', function (): void {
+    Livewire::test(AdminDonationEventForm::class)
+        ->set('form', validDonationEventSettingsForm())
+        ->call('save')
+        ->assertForbidden();
+});
+
+/**
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function validDonationEventSettingsForm(array $overrides = []): array
+{
+    return array_replace([
+        'title' => 'Höhenmeter für Menschen',
+        'slug' => '2027',
+        'starts_at' => '2027-09-11T13:00:05',
+        'ends_at' => '2027-09-11T18:00:06',
+        'registration_opens_at' => '2027-02-01T00:00:01',
+        'athlete_registration_closes_at' => '2027-09-11T14:00:02',
+        'donor_registration_closes_at' => '2027-09-19T23:59:59',
+        'location_name' => 'Brühlgut Stiftung',
+        'location_street' => 'Brühlbergstrasse 6',
+        'location_postal_code' => '8400',
+        'location_city' => 'Winterthur',
+        'location_url' => 'https://s.geo.admin.ch/example',
+        'is_published' => false,
+        'has_equal_split_option' => true,
+        'content' => [
+            'hero' => ['copy_md' => 'Hero 2027'],
+            'home' => [
+                'about_heading' => 'Um was geht es?',
+                'about_intro_md' => 'Einleitung',
+                'about_body_md' => 'Haupttext',
+            ],
+            'results' => ['heading_md' => 'Resultate 2027'],
+            'seo' => [
+                'meta_description_md' => 'Meta 2027',
+                'og_description_md' => 'OpenGraph 2027',
+            ],
+            'invoice' => ['additional_information' => 'Rechnung 2027'],
+        ],
+    ], $overrides);
+}

--- a/tests/Feature/AdminDonationEventSponsorsTest.php
+++ b/tests/Feature/AdminDonationEventSponsorsTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Components\AdminDonationEventSponsorsForm;
+use App\Models\DonationEvent;
+use App\Models\Sponsor;
+use App\Models\User;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+use function Pest\Laravel\get;
+
+it('shows sponsor tab on the event edit page', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    get(route('admin.donation-events.edit', $donationEvent))
+        ->assertSuccessful()
+        ->assertSee('Sponsor:innen')
+        ->assertSee('Sponsor:innen zuordnen');
+});
+
+it('loads sponsor assignments with pivot values', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $assignedSponsor = Sponsor::factory()->create(['name' => 'Alpha Sponsor']);
+    Sponsor::factory()->create(['name' => 'Beta Sponsor']);
+    $donationEvent->sponsors()->attach($assignedSponsor, [
+        'size' => 'large',
+        'contribution_text' => 'Finanziert die Verpflegung.',
+        'sort_order' => 20,
+        'is_published' => false,
+    ]);
+
+    Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => $donationEvent])
+        ->assertSet('sponsorRows.0.name', 'Alpha Sponsor')
+        ->assertSet('sponsorRows.0.attached', true)
+        ->assertSet('sponsorRows.0.size', 'large')
+        ->assertSet('sponsorRows.0.contribution_text', 'Finanziert die Verpflegung.')
+        ->assertSet('sponsorRows.0.sort_order', 20)
+        ->assertSet('sponsorRows.0.is_published', false)
+        ->assertSet('sponsorRows.1.name', 'Beta Sponsor')
+        ->assertSet('sponsorRows.1.attached', false)
+        ->assertSet('sponsorRows.1.size', 'medium')
+        ->assertSet('sponsorRows.1.is_published', true);
+});
+
+it('attaches updates and detaches sponsors', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $detachedSponsor = Sponsor::factory()->create(['name' => 'Alpha Sponsor']);
+    $attachedSponsor = Sponsor::factory()->create(['name' => 'Beta Sponsor']);
+    $donationEvent->sponsors()->attach($detachedSponsor, [
+        'size' => 'small',
+        'contribution_text' => 'Alter Beitrag',
+        'sort_order' => 10,
+        'is_published' => true,
+    ]);
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => $donationEvent])
+        ->set('sponsorRows.0.attached', false)
+        ->set('sponsorRows.1.attached', true)
+        ->set('sponsorRows.1.size', 'large')
+        ->set('sponsorRows.1.contribution_text', '  Neuer Anlassbeitrag  ')
+        ->set('sponsorRows.1.sort_order', 5)
+        ->set('sponsorRows.1.is_published', false)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    assertDatabaseMissing('donation_event_sponsor', [
+        'donation_event_id' => $donationEvent->id,
+        'sponsor_id' => $detachedSponsor->id,
+    ]);
+    assertDatabaseHas('donation_event_sponsor', [
+        'donation_event_id' => $donationEvent->id,
+        'sponsor_id' => $attachedSponsor->id,
+        'size' => 'large',
+        'contribution_text' => 'Neuer Anlassbeitrag',
+        'sort_order' => 5,
+        'is_published' => false,
+    ]);
+});
+
+it('requires valid pivot data for attached sponsors', function (): void {
+    Sponsor::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => DonationEvent::factory()->create()])
+        ->set('sponsorRows.0.attached', true)
+        ->set('sponsorRows.0.size', 'extra-large')
+        ->set('sponsorRows.0.contribution_text', '   ')
+        ->set('sponsorRows.0.sort_order', -1)
+        ->call('save')
+        ->assertHasErrors([
+            'sponsorRows.0.size' => 'in',
+            'sponsorRows.0.contribution_text' => 'required_if',
+            'sponsorRows.0.sort_order' => 'min',
+        ]);
+});
+
+it('allows detached sponsors without contribution text', function (): void {
+    Sponsor::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => DonationEvent::factory()->create()])
+        ->assertSet('sponsorRows.0.attached', false)
+        ->assertSet('sponsorRows.0.contribution_text', '')
+        ->call('save')
+        ->assertHasNoErrors();
+});
+
+it('validates duplicate sponsor rows', function (): void {
+    Sponsor::factory()->count(2)->create();
+
+    actingAs(User::factory()->create());
+
+    $component = Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => DonationEvent::factory()->create()]);
+    $sponsorRows = $component->get('sponsorRows');
+
+    $component
+        ->set('sponsorRows.1.id', $sponsorRows[0]['id'])
+        ->call('save')
+        ->assertHasErrors(['sponsorRows.1.id' => 'distinct']);
+});
+
+it('rejects unauthenticated sponsor mutations', function (): void {
+    Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => DonationEvent::factory()->create()])
+        ->call('save')
+        ->assertForbidden();
+});

--- a/tests/Feature/AdminDonationEventSponsorsTest.php
+++ b/tests/Feature/AdminDonationEventSponsorsTest.php
@@ -46,6 +46,7 @@ it('loads sponsor assignments with pivot values', function (): void {
         ->assertSet('sponsorRows.1.attached', false)
         ->assertSet('sponsorRows.1.size', 'medium')
         ->assertSet('sponsorRows.1.is_published', false)
+        ->assertSee('x-bind:disabled="!$wire.sponsorRows[0].attached"', escape: false)
         ->assertSee('Vom Anlass entfernen');
 });
 
@@ -84,6 +85,20 @@ it('attaches updates and detaches sponsors', function (): void {
         'sort_order' => 5,
         'is_published' => false,
     ]);
+});
+
+it('undoes a new sponsor assignment before saving', function (): void {
+    Sponsor::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => DonationEvent::factory()->create()])
+        ->call('attachSponsor', 0)
+        ->assertSet('sponsorRows.0.attached', true)
+        ->assertSee('Zuordnung rückgängig')
+        ->call('detachSponsor', 0)
+        ->assertSet('sponsorRows.0.attached', false)
+        ->assertDontSee('Zuordnung rückgängig');
 });
 
 it('requires valid pivot data for attached sponsors', function (): void {

--- a/tests/Feature/AdminDonationEventSponsorsTest.php
+++ b/tests/Feature/AdminDonationEventSponsorsTest.php
@@ -19,7 +19,9 @@ it('shows sponsor tab on the event edit page', function (): void {
     get(route('admin.donation-events.edit', $donationEvent))
         ->assertSuccessful()
         ->assertSee('Sponsor:innen')
-        ->assertSee('Sponsor:innen zuordnen');
+        ->assertSee('Zugeordnete Sponsor:innen')
+        ->assertSee('Verfügbare Sponsor:innen')
+        ->assertSee('Zuordnungen');
 });
 
 it('loads sponsor assignments with pivot values', function (): void {
@@ -43,7 +45,8 @@ it('loads sponsor assignments with pivot values', function (): void {
         ->assertSet('sponsorRows.1.name', 'Beta Sponsor')
         ->assertSet('sponsorRows.1.attached', false)
         ->assertSet('sponsorRows.1.size', 'medium')
-        ->assertSet('sponsorRows.1.is_published', true);
+        ->assertSet('sponsorRows.1.is_published', false)
+        ->assertSee('Vom Anlass entfernen');
 });
 
 it('attaches updates and detaches sponsors', function (): void {
@@ -96,9 +99,39 @@ it('requires valid pivot data for attached sponsors', function (): void {
         ->call('save')
         ->assertHasErrors([
             'sponsorRows.0.size' => 'in',
-            'sponsorRows.0.contribution_text' => 'required_if',
+            'sponsorRows.0.contribution_text' => 'required',
             'sponsorRows.0.sort_order' => 'min',
         ]);
+});
+
+it('ignores invalid pivot data for detached sponsors', function (): void {
+    Sponsor::factory()->create();
+
+    actingAs(User::factory()->create());
+
+    Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => DonationEvent::factory()->create()])
+        ->set('sponsorRows.0.size', 'extra-large')
+        ->set('sponsorRows.0.sort_order', -1)
+        ->call('save')
+        ->assertHasNoErrors();
+});
+
+it('loads assigned sponsors in public order and available sponsors alphabetically', function (): void {
+    $donationEvent = DonationEvent::factory()->create();
+    $laterByName = Sponsor::factory()->create(['name' => 'Zulu Assigned']);
+    $firstByName = Sponsor::factory()->create(['name' => 'Alpha Assigned']);
+    Sponsor::factory()->create(['name' => 'Beta Available']);
+    Sponsor::factory()->create(['name' => 'Alpha Available']);
+
+    $pivot = ['size' => 'medium', 'contribution_text' => 'Beitrag', 'is_published' => true];
+    $donationEvent->sponsors()->attach($laterByName, [...$pivot, 'sort_order' => 10]);
+    $donationEvent->sponsors()->attach($firstByName, [...$pivot, 'sort_order' => 20]);
+
+    Livewire::test(AdminDonationEventSponsorsForm::class, ['donationEvent' => $donationEvent])
+        ->assertSet('sponsorRows.0.name', 'Zulu Assigned')
+        ->assertSet('sponsorRows.1.name', 'Alpha Assigned')
+        ->assertSet('sponsorRows.2.name', 'Alpha Available')
+        ->assertSet('sponsorRows.3.name', 'Beta Available');
 });
 
 it('allows detached sponsors without contribution text', function (): void {

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -13,8 +13,11 @@ it('renders home page with athlete and donation counts', function (): void {
     $response->assertOk();
 });
 
-it('renders home page with partners and sponsors for active event', function (): void {
-    $event = DonationEvent::factory()->create(['is_published' => true]);
+it('renders home page with event title, partners, and sponsors for active event', function (): void {
+    $event = DonationEvent::factory()->create([
+        'title' => 'Test Anlass aus der Datenbank',
+        'is_published' => true,
+    ]);
     $settings = app(EventSettings::class);
     $settings->current_event_id = $event->id;
     $settings->save();
@@ -36,6 +39,7 @@ it('renders home page with partners and sponsors for active event', function ():
     $response = get(route('home'));
 
     $response->assertOk();
+    $response->assertSee('Test Anlass aus der Datenbank');
     $response->assertSee('Test Partner');
     $response->assertSee('Test Sponsor');
     $response->assertSee('Generic sponsor description');

--- a/tests/Feature/Http/Controllers/HomeControllerTest.php
+++ b/tests/Feature/Http/Controllers/HomeControllerTest.php
@@ -70,3 +70,23 @@ it('does not show unpublished partners or sponsors on home', function (): void {
     $response->assertDontSee('Hidden Partner');
     $response->assertDontSee('Hidden Sponsor');
 });
+
+it('uses default metadata when event SEO content is blank', function (): void {
+    $event = DonationEvent::factory()->create([
+        'is_published' => true,
+        'content' => [
+            'seo' => [
+                'meta_description_md' => '   ',
+                'og_description_md' => '',
+            ],
+        ],
+    ]);
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $event->id;
+    $settings->save();
+
+    get(route('home'))
+        ->assertSuccessful()
+        ->assertSee('content="Höhenmeter für Menschen: Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen."', escape: false)
+        ->assertSee('content="Ein Spendenlauf in Winterthur für lokale Benefizpartner:innen."', escape: false);
+});

--- a/tests/Feature/Livewire/ResultsTest.php
+++ b/tests/Feature/Livewire/ResultsTest.php
@@ -7,7 +7,24 @@ use App\Models\DonationEvent;
 use App\Models\ExternalUser;
 use App\Models\Partner;
 use App\Models\SportType;
+use App\Settings\EventSettings;
 use Livewire\Livewire;
+
+use function Pest\Laravel\get;
+
+it('falls back to the default results heading when event content is empty', function (): void {
+    $donationEvent = DonationEvent::factory()->create([
+        'is_published' => true,
+        'content' => ['results' => ['heading_md' => '']],
+    ]);
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $donationEvent->id;
+    $settings->save();
+
+    get(route('results'))
+        ->assertSuccessful()
+        ->assertSeeText('Resultate');
+});
 
 it('renders successfully and shows per-partner section', function () {
     Livewire::test(Results::class)


### PR DESCRIPTION
Adds one admin workflow for creating and editing donation events, including event-specific public content and partner/sponsor assignments. This makes event configuration maintainable without changing database schema or dependencies.

## Details

- [donation-event-settings.blade.php](https://github.com/fuermenschen/hfm/blob/feat/event-edit-page/resources/views/pages/admin/donation-event-settings.blade.php) - composes event, partner, and sponsor settings tabs
- [AdminDonationEventForm.php](https://github.com/fuermenschen/hfm/blob/feat/event-edit-page/app/Components/AdminDonationEventForm.php) - validates and saves core event data and public content
- [AdminDonationEventPartnersForm.php](https://github.com/fuermenschen/hfm/blob/feat/event-edit-page/app/Components/AdminDonationEventPartnersForm.php) - manages event-specific partner visibility and ordering
- [AdminDonationEventSponsorsForm.php](https://github.com/fuermenschen/hfm/blob/feat/event-edit-page/app/Components/AdminDonationEventSponsorsForm.php) - manages sponsor presentation and event contributions

## Reviewer Setup

In this PR vs `origin/main`, changes were made in Laravel/Livewire admin forms, Blade views, routes, JavaScript, and tests. You likely need to run:

```sh
npm run build
php artisan boost:update
php artisan optimize:clear
```

---
**«Act only according to that maxim whereby you can, at the same time, will that it should become a universal law.»**
_Immanuel Kant_