### PR TITLE
feat: add event filtering to admin dashboard

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,17 +30,38 @@ jobs:
       - name: Validate lockfile consistency
         run: |
           set -euo pipefail
-          BASE_SHA="${{ github.event.pull_request.base.sha }}"
-          HEAD_SHA="${{ github.sha }}"
-          CHANGED_FILES="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA")"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          BASE_SHA="$(git merge-base "${{ github.event.pull_request.base.sha }}" "$HEAD_SHA")"
 
-          if echo "$CHANGED_FILES" | grep -qx "package.json" && ! echo "$CHANGED_FILES" | grep -qx "package-lock.json"; then
-            echo "package.json changed without package-lock.json. Please update and commit package-lock.json."
+          dependencies_changed() {
+            local manifest="$1"
+            local filter="$2"
+
+            ! diff --brief \
+              <(git show "$BASE_SHA:$manifest" | jq --sort-keys "$filter") \
+              <(git show "$HEAD_SHA:$manifest" | jq --sort-keys "$filter") \
+              >/dev/null
+          }
+
+          lockfile_unchanged() {
+            git diff --quiet "$BASE_SHA" "$HEAD_SHA" -- "$1"
+          }
+
+          if dependencies_changed package.json '{
+            dependencies: (.dependencies // {}),
+            devDependencies: (.devDependencies // {}),
+            optionalDependencies: (.optionalDependencies // {}),
+            peerDependencies: (.peerDependencies // {})
+          }' && lockfile_unchanged package-lock.json; then
+            echo "package.json dependencies changed without package-lock.json. Please update and commit package-lock.json."
             exit 1
           fi
 
-          if echo "$CHANGED_FILES" | grep -qx "composer.json" && ! echo "$CHANGED_FILES" | grep -qx "composer.lock"; then
-            echo "composer.json changed without composer.lock. Please update and commit composer.lock."
+          if dependencies_changed composer.json '{
+            require: (.require // {}),
+            "require-dev": (."require-dev" // {})
+          }' && lockfile_unchanged composer.lock; then
+            echo "composer.json dependencies changed without composer.lock. Please update and commit composer.lock."
             exit 1
           fi
 

--- a/app/Actions/GetDashboardDataAction.php
+++ b/app/Actions/GetDashboardDataAction.php
@@ -6,11 +6,13 @@ namespace App\Actions;
 
 use App\Models\AthleteRegistration;
 use App\Models\Donation;
+use App\Models\DonationEvent;
 use App\Models\ExternalUser;
 use App\Models\Partner;
 use App\Services\AthleteService;
 use App\Services\DonationService;
 use App\Services\DonorService;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 
 class GetDashboardDataAction
@@ -24,6 +26,8 @@ class GetDashboardDataAction
     /**
      * @return array{
      *     greeting: string,
+     *     events: Collection<int, DonationEvent>,
+     *     selectedEventSlug: ?string,
      *     partners: Collection<int, Partner>,
      *     athleteCount: int,
      *     donorCount: int,
@@ -41,28 +45,42 @@ class GetDashboardDataAction
      *     mostRecentActivities: array<int, array<string, mixed>>,
      * }
      */
-    public function __invoke(): array
+    public function __invoke(?DonationEvent $event = null): array
     {
         $greeting = $this->greeting();
+        $events = DonationEvent::query()
+            ->latest('starts_at')
+            ->get(['id', 'title', 'slug', 'is_published']);
+        $selectedEventSlug = $event?->slug;
 
-        $partners = Partner::query()
-            ->select(['id', 'name'])
-            ->orderBy('name')
-            ->get();
+        $partners = $event instanceof DonationEvent
+            ? $event->partners()->select(['partners.id', 'partners.name'])->orderBy('name')->get()
+            : Partner::query()->select(['id', 'name'])->orderBy('name')->get();
 
-        $athleteCount = $this->athleteService->count();
-        $donorCount = $this->donorService->count();
-        $donationCount = (int) Donation::query()->count();
+        $athleteCount = $event instanceof DonationEvent
+            ? (int) $this->athleteService->forEvent($event)->count()
+            : $this->athleteService->count();
+        $donorCount = $event instanceof DonationEvent
+            ? (int) $this->donorService->forEvent($event)->count()
+            : $this->donorService->count();
+        $donationCount = (int) $this->donationsQuery($event)->count();
 
-        $verifiedAthleteCount = $this->athleteService->verifiedCount();
-        $verifiedDonationCount = (int) Donation::query()->where('verified', true)->count();
+        $verifiedAthleteCount = $event instanceof DonationEvent
+            ? (int) $this->registrationsQuery($event)
+                ->where('verified', true)
+                ->distinct()
+                ->count('external_user_id')
+            : $this->athleteService->verifiedCount();
+        $verifiedDonationCount = (int) $this->donationsQuery($event)->where('verified', true)->count();
 
         $meanNumberOfDonations = $athleteCount > 0 ? (float) ($donationCount / $athleteCount) : 0.0;
-        $meanNumberOfRounds = $this->meanNumberOfRounds();
+        $meanNumberOfRounds = $this->meanNumberOfRounds($event);
         $meanNumberOfDonationsDonor = $donorCount > 0 ? (float) ($donationCount / $donorCount) : 0.0;
-        $meanDonationAmount = (float) (Donation::query()->avg('amount_per_round') ?? 0.0);
+        $meanDonationAmount = (float) ($this->donationsQuery($event)->avg('amount_per_round') ?? 0.0);
 
-        $donations = Donation::query()->with(['athleteRegistration.partner', 'athleteRegistration.externalUser'])->get();
+        $donations = $this->donationsQuery($event)
+            ->with(['athleteRegistration.partner', 'athleteRegistration.externalUser'])
+            ->get();
 
         $expectedDonationAmount = $this->donationService->calculateEstimatedTotal($donations);
         $actualTotalAmount = $this->donationService->calculateActualTotal($donations);
@@ -70,10 +88,12 @@ class GetDashboardDataAction
         $estimatedAmounts = $this->donationService->calculateEstimatedTotalPerPartner($donations);
         $actualAmounts = $this->donationService->calculateActualTotalPerPartner($donations);
 
-        $mostRecentActivities = $this->buildRecentActivities();
+        $mostRecentActivities = $this->buildRecentActivities($event);
 
         return compact(
             'greeting',
+            'events',
+            'selectedEventSlug',
             'partners',
             'athleteCount',
             'donorCount',
@@ -111,23 +131,31 @@ class GetDashboardDataAction
     /**
      * @return array<int, array<string, mixed>>
      */
-    protected function buildRecentActivities(): array
+    protected function buildRecentActivities(?DonationEvent $event): array
     {
         $sevenDaysAgo = now()->subDays(7);
 
-        $recentAthletes = $this->athleteService->all()
+        $recentExternalUsers = ExternalUser::query()
             ->where('created_at', '>=', $sevenDaysAgo)
+            ->when($event instanceof DonationEvent, function (Builder $query) use ($event): void {
+                $query->where(function (Builder $participants) use ($event): void {
+                    $participants
+                        ->whereHas('athleteRegistrations', fn (Builder $registrations): Builder => $registrations->where('donation_event_id', $event->id))
+                        ->orWhereHas('donationsAsDonor.athleteRegistration', fn (Builder $registration): Builder => $registration->where('donation_event_id', $event->id));
+                });
+            })
             ->latest()
             ->limit(30)
             ->get(['id', 'first_name', 'last_name', 'created_at']);
 
-        $recentDonors = $this->donorService->all()
+        $recentAthleteRegistrations = $this->registrationsQuery($event)
             ->where('created_at', '>=', $sevenDaysAgo)
+            ->with('externalUser:id,first_name,last_name')
             ->latest()
             ->limit(30)
-            ->get(['id', 'first_name', 'last_name', 'created_at']);
+            ->get(['id', 'external_user_id', 'created_at']);
 
-        $recentDonations = Donation::query()
+        $recentDonations = $this->donationsQuery($event)
             ->where('created_at', '>=', $sevenDaysAgo)
             ->with([
                 'donorExternalUser:id,first_name,last_name',
@@ -139,24 +167,19 @@ class GetDashboardDataAction
 
         $activities = [];
 
-        foreach ($recentAthletes as $athlete) {
-            if (! $athlete instanceof ExternalUser) {
-                continue;
-            }
-
+        foreach ($recentExternalUsers as $externalUser) {
             $activities[] = [
-                'type' => 'athlete',
-                'name' => $athlete->privacyName(),
-                'created_at' => $athlete->created_at,
+                'type' => 'external_user',
+                'name' => $externalUser->privacyName(),
+                'created_at' => $externalUser->created_at,
             ];
         }
 
-        foreach ($recentDonors as $donor) {
-            /** @var ExternalUser $donor */
+        foreach ($recentAthleteRegistrations as $registration) {
             $activities[] = [
-                'type' => 'donor',
-                'name' => $donor->privacyName(),
-                'created_at' => $donor->created_at,
+                'type' => 'athlete_registration',
+                'name' => $registration->externalUser->privacyName(),
+                'created_at' => $registration->created_at,
             ];
         }
 
@@ -179,10 +202,26 @@ class GetDashboardDataAction
         return array_reverse($activities);
     }
 
-    protected function meanNumberOfRounds(): float
+    protected function meanNumberOfRounds(?DonationEvent $event): float
     {
-        $mean = AthleteRegistration::query()->avg('rounds_estimated');
+        $mean = $this->registrationsQuery($event)->avg('rounds_estimated');
 
         return (float) ($mean ?? 0.0);
+    }
+
+    /** @return Builder<AthleteRegistration> */
+    protected function registrationsQuery(?DonationEvent $event): Builder
+    {
+        return AthleteRegistration::query()
+            ->when($event instanceof DonationEvent, fn (Builder $query): Builder => $query->where('donation_event_id', $event->id));
+    }
+
+    /** @return Builder<Donation> */
+    protected function donationsQuery(?DonationEvent $event): Builder
+    {
+        return Donation::query()
+            ->when($event instanceof DonationEvent, function (Builder $query) use ($event): void {
+                $query->whereHas('athleteRegistration', fn (Builder $registration): Builder => $registration->where('donation_event_id', $event->id));
+            });
     }
 }

--- a/app/Components/AdminDonationTable.php
+++ b/app/Components/AdminDonationTable.php
@@ -17,7 +17,7 @@ class AdminDonationTable extends AbstractDatatableComponent
     public string $sortField = 'created_at';
 
     #[Url(as: 'anlass', except: '')]
-    public ?string $eventId = '';
+    public ?string $eventSlug = '';
 
     protected DonationService $donationService;
 
@@ -105,24 +105,16 @@ class AdminDonationTable extends AbstractDatatableComponent
 
     protected function applyFilters(Builder $query): void
     {
-        if ($this->eventId === null || $this->eventId === '') {
+        if ($this->eventSlug === null || $this->eventSlug === '') {
             return;
         }
 
-        $eventId = ctype_digit($this->eventId) ? (int) $this->eventId : 0;
-
-        if ($eventId < 1) {
-            $query->whereRaw('1 = 0');
-
-            return;
-        }
-
-        $query->whereHas('athleteRegistration', fn (Builder $registration): Builder => $registration->where('donation_event_id', $eventId));
+        $query->whereHas('athleteRegistration.donationEvent', fn (Builder $event): Builder => $event->where('slug', $this->eventSlug));
     }
 
     protected function tableFilterProperties(): array
     {
-        return ['eventId'];
+        return ['eventSlug'];
     }
 
     protected function defaultSortColumn(): string

--- a/app/Components/AdminPersonTable.php
+++ b/app/Components/AdminPersonTable.php
@@ -7,6 +7,7 @@ namespace App\Components;
 use App\Models\DonationEvent;
 use App\Models\ExternalUser;
 use App\Services\AthleteService;
+use App\Services\CurrentDonationEventService;
 use App\Services\DonorService;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
@@ -23,16 +24,22 @@ class AdminPersonTable extends AbstractDatatableComponent
     public string $role = '';
 
     #[Url(as: 'anlass', except: '')]
-    public ?string $eventId = '';
+    public ?string $eventSlug = '';
 
     protected AthleteService $athleteService;
 
     protected DonorService $donorService;
 
-    public function boot(AthleteService $athleteService, DonorService $donorService): void
-    {
+    protected CurrentDonationEventService $currentDonationEventService;
+
+    public function boot(
+        AthleteService $athleteService,
+        DonorService $donorService,
+        CurrentDonationEventService $currentDonationEventService,
+    ): void {
         $this->athleteService = $athleteService;
         $this->donorService = $donorService;
+        $this->currentDonationEventService = $currentDonationEventService;
     }
 
     public function mount(string $role = ''): void
@@ -40,6 +47,11 @@ class AdminPersonTable extends AbstractDatatableComponent
         throw_unless(in_array($role, ['athlete', 'donor'], true), \InvalidArgumentException::class, 'Invalid person role.');
 
         $this->role = $role;
+
+        if (! request()->query->has('anlass') && ($this->eventSlug === null || $this->eventSlug === '')) {
+            $currentEvent = $this->currentDonationEventService->current();
+            $this->eventSlug = $currentEvent instanceof DonationEvent ? $currentEvent->slug : '';
+        }
 
         parent::mount();
     }
@@ -80,30 +92,22 @@ class AdminPersonTable extends AbstractDatatableComponent
 
     protected function applyFilters(Builder $query): void
     {
-        if ($this->eventId === null || $this->eventId === '') {
-            return;
-        }
-
-        $eventId = ctype_digit($this->eventId) ? (int) $this->eventId : 0;
-
-        if ($eventId < 1) {
-            $query->whereRaw('1 = 0');
-
+        if ($this->eventSlug === null || $this->eventSlug === '') {
             return;
         }
 
         if ($this->role === 'athlete') {
-            $query->whereHas('athleteRegistrations', fn (Builder $registrations): Builder => $registrations->where('donation_event_id', $eventId));
+            $query->whereHas('athleteRegistrations.donationEvent', fn (Builder $event): Builder => $event->where('slug', $this->eventSlug));
 
             return;
         }
 
-        $query->whereHas('donationsAsDonor.athleteRegistration', fn (Builder $registration): Builder => $registration->where('donation_event_id', $eventId));
+        $query->whereHas('donationsAsDonor.athleteRegistration.donationEvent', fn (Builder $event): Builder => $event->where('slug', $this->eventSlug));
     }
 
     protected function tableFilterProperties(): array
     {
-        return ['eventId'];
+        return ['eventSlug'];
     }
 
     protected function defaultSortColumn(): string

--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Admin;
+
+use App\Actions\GetDashboardDataAction;
+use App\Http\Controllers\Controller;
+use App\Models\DonationEvent;
+use App\Services\CurrentDonationEventService;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+
+class DashboardController extends Controller
+{
+    public function __invoke(
+        Request $request,
+        CurrentDonationEventService $currentDonationEventService,
+        GetDashboardDataAction $getDashboardData,
+    ): Factory|View {
+        $event = $currentDonationEventService->current();
+
+        if ($request->query->has('anlass')) {
+            $eventSlug = $request->query('anlass');
+
+            if ($eventSlug === null || $eventSlug === '') {
+                $event = null;
+            } else {
+                abort_unless(is_string($eventSlug), 404);
+
+                $event = DonationEvent::query()->where('slug', $eventSlug)->firstOrFail();
+            }
+        }
+
+        return view('pages.admin.dashboard', $getDashboardData($event));
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
-use App\Actions\GetDashboardDataAction;
 use App\Services\CurrentDonationEventService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Auth\User;
@@ -48,11 +47,6 @@ class AppServiceProvider extends ServiceProvider
 
         Gate::define('viewPulse', fn (User $user): true => true);
         Gate::define('viewLogViewer', fn (User $user): true => true);
-
-        // Inject computed dashboard data via a view composer
-        View::composer('pages.admin.dashboard', function ($view): void {
-            $view->with(resolve(GetDashboardDataAction::class)());
-        });
 
         View::composer('*', function ($view): void {
             $eventService = resolve(CurrentDonationEventService::class);

--- a/app/Services/AthleteService.php
+++ b/app/Services/AthleteService.php
@@ -18,7 +18,6 @@ class AthleteService
         return $this->baseQuery();
     }
 
-    // @phpstan-ignore-next-line shipmonk.deadMethod
     public function forEvent(DonationEvent|int $event): Builder
     {
         $eventId = $event instanceof DonationEvent ? $event->id : $event;

--- a/app/Services/DonorService.php
+++ b/app/Services/DonorService.php
@@ -18,8 +18,6 @@ class DonorService
         return $this->baseQuery();
     }
 
-    // TODO(refactor-external-user): Wire forEvent into production consumers after donor model migration lands.
-    // @phpstan-ignore-next-line shipmonk.deadMethod
     public function forEvent(DonationEvent|int $event): Builder
     {
         $eventId = $event instanceof DonationEvent ? $event->id : $event;

--- a/app/Support/DeadCode/ServiceConstructorInjectionUsageProvider.php
+++ b/app/Support/DeadCode/ServiceConstructorInjectionUsageProvider.php
@@ -56,12 +56,13 @@ class ServiceConstructorInjectionUsageProvider implements MemberUsageProvider
 
                 $parameterClassName = $type->getName();
 
-                if (! str_starts_with($parameterClassName, 'App\\Services\\')) {
+                if (! str_starts_with($parameterClassName, 'App\\Services\\')
+                    && ! str_starts_with($parameterClassName, 'App\\Actions\\')) {
                     continue;
                 }
 
                 $usages[] = new ClassMethodUsage(
-                    UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Service constructor resolved by Laravel container via typed method injection')),
+                    UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Dependency constructor resolved by Laravel container via typed method injection')),
                     new ClassMethodRef($parameterClassName, '__construct', possibleDescendant: false),
                 );
             }

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,7 @@
             "npm run e2e"
         ],
         "lint:ai": [
-            "vendor/bin/rector process --dry-run --no-diffs --ansi",
+            "vendor/bin/rector process --ansi",
             "vendor/bin/pint --dirty -q",
             "vendor/bin/peck -q"
         ],

--- a/e2e/admin-pages.spec.mjs
+++ b/e2e/admin-pages.spec.mjs
@@ -7,7 +7,8 @@ const adminRoutes = [
     "/admin/partner",
     "/admin/sponsoren",
     "/admin/faqs",
-    "/admin/externe-personen",
+    "/admin/sportlerinnen",
+    "/admin/spenderinnen",
     "/admin/spenden",
     "/admin/dateien",
     "/admin/tools",
@@ -22,7 +23,10 @@ function runArtisan(args) {
 }
 
 function ensureSeededDatabase() {
-    const userCount = Number.parseInt(runArtisan(["tinker", "--execute=echo App\\Models\\User::query()->count();"]), 10);
+    const userCount = Number.parseInt(
+        runArtisan(["tinker", "--execute=echo App\\Models\\User::query()->count();"]),
+        10,
+    );
 
     if (Number.isNaN(userCount) || userCount === 0) {
         runArtisan(["db:seed", "--no-interaction"]);
@@ -38,7 +42,11 @@ function signedAdminLoginUrl() {
 
 async function waitForImagesAndIdle(page) {
     await page.waitForLoadState("networkidle");
-    await page.waitForFunction(() => Array.from(document.images).filter((img) => img.hasAttribute("src") && !img.src.startsWith("data:")).every((img) => img.complete && img.naturalWidth > 0));
+    await page.waitForFunction(() =>
+        Array.from(document.images)
+            .filter((img) => img.hasAttribute("src") && !img.src.startsWith("data:"))
+            .every((img) => img.complete && img.naturalWidth > 0),
+    );
 }
 
 async function slowScroll(page) {

--- a/resources/views/components/admin/activity-list-entry.blade.php
+++ b/resources/views/components/admin/activity-list-entry.blade.php
@@ -1,60 +1,25 @@
 @props(['activity'])
 
 @php
+    [$activityText, $activityIcon] = match ($activity['type']) {
+        'external_user' => [$activity['name'].' wurde als externe Person registriert.', 'user'],
+        'athlete_registration' => [$activity['name'].' hat sich als Sportler:in registriert.', 'user-plus'],
+        'donation' => [$activity['name'].' hat eine Spende für '.$activity['name2'].' eingetragen.', 'banknotes'],
+    };
 
-    $activity_text = '';
-    $activity_symbol = '';
-
-    switch ($activity['type']) {
-        case 'athlete':
-            $activity_text = $activity['name'] . ' hat sich als Sportler:in registriert.';
-            $activity_symbol = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path d="M5.25 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM2.25 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM18.75 7.5a.75.75 0 0 0-1.5 0v2.25H15a.75.75 0 0 0 0 1.5h2.25v2.25a.75.75 0 0 0 1.5 0v-2.25H21a.75.75 0 0 0 0-1.5h-2.25V7.5Z" /></svg>';
-            break;
-        case 'donor':
-            $activity_text = $activity['name'] . ' hat sich als Spender:in registriert.';
-            $activity_symbol = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path d="M5.25 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM2.25 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM18.75 7.5a.75.75 0 0 0-1.5 0v2.25H15a.75.75 0 0 0 0 1.5h2.25v2.25a.75.75 0 0 0 1.5 0v-2.25H21a.75.75 0 0 0 0-1.5h-2.25V7.5Z" /></svg>';
-            break;
-        case 'donation':
-            $activity_text = $activity['name'] . ' hat eine Spende für ' . $activity['name2'] . ' eingetragen.';
-            $activity_symbol = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path d="M12 7.5a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z" /><path fill-rule="evenodd" d="M1.5 4.875C1.5 3.839 2.34 3 3.375 3h17.25c1.035 0 1.875.84 1.875 1.875v9.75c0 1.036-.84 1.875-1.875 1.875H3.375A1.875 1.875 0 0 1 1.5 14.625v-9.75ZM8.25 9.75a3.75 3.75 0 1 1 7.5 0 3.75 3.75 0 0 1-7.5 0ZM18.75 9a.75.75 0 0 0-.75.75v.008c0 .414.336.75.75.75h.008a.75.75 0 0 0 .75-.75V9.75a.75.75 0 0 0-.75-.75h-.008ZM4.5 9.75A.75.75 0 0 1 5.25 9h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V9.75Z" clip-rule="evenodd" /><path d="M2.25 18a.75.75 0 0 0 0 1.5c5.4 0 10.63.722 15.6 2.075 1.19.324 2.4-.558 2.4-1.82V18.75a.75.75 0 0 0-.75-.75H2.25Z" /></svg>';
-            break;
-        case 'payment':
-            $activity_text = $activity['name'] . ' hat eine Zahlung getätigt.';
-            $activity_symbol = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path d="M12 7.5a2.25 2.25 0 1 0 0 4.5 2.25 2.25 0 0 0 0-4.5Z" /><path fill-rule="evenodd" d="M1.5 4.875C1.5 3.839 2.34 3 3.375 3h17.25c1.035 0 1.875.84 1.875 1.875v9.75c0 1.036-.84 1.875-1.875 1.875H3.375A1.875 1.875 0 0 1 1.5 14.625v-9.75ZM8.25 9.75a3.75 3.75 0 1 1 7.5 0 3.75 3.75 0 0 1-7.5 0ZM18.75 9a.75.75 0 0 0-.75.75v.008c0 .414.336.75.75.75h.008a.75.75 0 0 0 .75-.75V9.75a.75.75 0 0 0-.75-.75h-.008ZM4.5 9.75A.75.75 0 0 1 5.25 9h.008a.75.75 0 0 1 .75.75v.008a.75.75 0 0 1-.75.75H5.25a.75.75 0 0 1-.75-.75V9.75Z" clip-rule="evenodd" /><path d="M2.25 18a.75.75 0 0 0 0 1.5c5.4 0 10.63.722 15.6 2.075 1.19.324 2.4-.558 2.4-1.82V18.75a.75.75 0 0 0-.75-.75H2.25Z" /></svg>';
-            break;
-        case 'member':
-            $activity_text = $activity['name'] . ' ist Mitglied geworden.';
-            $activity_symbol = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" class="size-6"><path d="M5.25 6.375a4.125 4.125 0 1 1 8.25 0 4.125 4.125 0 0 1-8.25 0ZM2.25 19.125a7.125 7.125 0 0 1 14.25 0v.003l-.001.119a.75.75 0 0 1-.363.63 13.067 13.067 0 0 1-6.761 1.873c-2.472 0-4.786-.684-6.76-1.873a.75.75 0 0 1-.364-.63l-.001-.122ZM18.75 7.5a.75.75 0 0 0-1.5 0v2.25H15a.75.75 0 0 0 0 1.5h2.25v2.25a.75.75 0 0 0 1.5 0v-2.25H21a.75.75 0 0 0 0-1.5h-2.25V7.5Z" />
-</svg>
-';
-            break;
-    }
-
-    $datetime_text = date('d. M Y H:i', strtotime($activity['created_at']));
-
+    $createdAt = $activity['created_at'];
 @endphp
 
-<li>
-    <div class="relative pb-8">
-        <span class="absolute left-4 top-4 -ml-px h-full w-0.5 bg-base-200 dark:bg-base-700"
-              aria-hidden="true"></span>
-        <div class="relative flex space-x-3">
-            <div>
-            <span
-                class="flex h-8 w-8 items-center justify-center rounded-full bg-base-100 text-base-700 ring-4 ring-base-900 dark:bg-base-800 dark:text-base-200 dark:ring-base-100">
-                {!! $activity_symbol !!}
-            </span>
-            </div>
-            <div class="flex min-w-0 flex-1 justify-between space-x-4 pt-1.5 pl-3">
-                <div>
-                    <p class="text-sm">
-                        {{ $activity_text }}
-                    </p>
-                </div>
-                <div class="whitespace-nowrap text-right text-sm">
-                    <time datetime="2020-09-20">{{ $datetime_text }}</time>
-                </div>
-            </div>
+<flux:timeline.item align="start">
+    <flux:timeline.indicator>
+        <flux:icon :name="$activityIcon" variant="micro" />
+    </flux:timeline.indicator>
+    <flux:timeline.content>
+        <div class="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
+            <flux:text>{{ $activityText }}</flux:text>
+            <flux:text class="whitespace-nowrap text-sm">
+                <time datetime="{{ $createdAt->toIso8601String() }}">{{ $createdAt->format('d.m.Y H:i') }}</time>
+            </flux:text>
         </div>
-    </div>
-</li>
+    </flux:timeline.content>
+</flux:timeline.item>

--- a/resources/views/components/admin/activity-list.blade.php
+++ b/resources/views/components/admin/activity-list.blade.php
@@ -1,11 +1,15 @@
 @props(['title', 'activities'])
 
 <div class="mt-9 max-w-xl">
-    <h2 class="text-xl font-semibold leading-6">{{ $title }}</h2>
+    <flux:heading size="xl">{{ $title }}</flux:heading>
 
-    <ul role="list" class="mt-9">
-        @foreach ($activities as $activity)
+    @if ($activities === [])
+        <flux:text class="mt-5">Keine Aktivitäten in den letzten sieben Tagen.</flux:text>
+    @else
+        <flux:timeline align="start" class="mt-7">
+            @foreach ($activities as $activity)
             <x-admin.activity-list-entry :activity="$activity" />
-        @endforeach
-    </ul>
+            @endforeach
+        </flux:timeline>
+    @endif
 </div>

--- a/resources/views/components/admin/stat-card.blade.php
+++ b/resources/views/components/admin/stat-card.blade.php
@@ -1,6 +1,8 @@
-<a
-    href="{{ route($route) }}" wire:navigate.hover
-    class="overflow-hidden rounded-lg bg-base-50 px-4 py-5 shadow sm:p-6 dark:bg-base-800">
-    <dt class="truncate text-sm font-medium">{{ $title }}</dt>
-    <dd class="mt-1 text-3xl font-semibold tracking-tight">{{ $value }}</dd>
+@props(['title', 'value', 'route', 'routeParameters' => []])
+
+<a href="{{ route($route, $routeParameters) }}" wire:navigate.hover class="block">
+    <flux:card class="h-full">
+        <dt><flux:text class="truncate">{{ $title }}</flux:text></dt>
+        <dd class="mt-1 text-3xl font-semibold tracking-tight tabular-nums">{{ $value }}</dd>
+    </flux:card>
 </a>

--- a/resources/views/components/admin/tables/donation-table.blade.php
+++ b/resources/views/components/admin/tables/donation-table.blade.php
@@ -126,7 +126,7 @@
                                 @if (trim($search) !== '')
                                     <flux:text>Keine Treffer für "{{ $search }}".</flux:text>
                                     <flux:button variant="ghost" size="sm" wire:click="$set('search', '')">Suche zurücksetzen</flux:button>
-                                @elseif ($eventId !== null && $eventId !== '')
+                                @elseif ($eventSlug !== null && $eventSlug !== '')
                                     <flux:text>Keine Spenden für diesen Anlass vorhanden.</flux:text>
                                 @else
                                     <flux:text>Keine Spenden vorhanden.</flux:text>

--- a/resources/views/components/admin/tables/person-table.blade.php
+++ b/resources/views/components/admin/tables/person-table.blade.php
@@ -89,7 +89,7 @@
                                     @if (trim($search) !== '')
                                         <flux:text>Keine Treffer für "{{ $search }}".</flux:text>
                                         <flux:button variant="ghost" size="sm" wire:click="$set('search', '')">Suche zurücksetzen</flux:button>
-                                    @elseif ($eventId !== null && $eventId !== '')
+                                    @elseif ($eventSlug !== null && $eventSlug !== '')
                                         <flux:text>Keine {{ $this->roleLabel() }} für diesen Anlass vorhanden.</flux:text>
                                     @else
                                         <flux:text>Keine {{ $this->roleLabel() }} vorhanden.</flux:text>

--- a/resources/views/components/datatable/event-filter.blade.php
+++ b/resources/views/components/datatable/event-filter.blade.php
@@ -1,8 +1,8 @@
 @props(['events'])
 
-<flux:select wire:model.live="eventId" variant="listbox" searchable clearable placeholder="Alle Anlässe" class="w-full sm:w-72">
+<flux:select wire:model.live="eventSlug" variant="listbox" searchable clearable placeholder="Alle Anlässe" class="w-full sm:w-72">
     @foreach ($events as $event)
-        <flux:select.option :value="(string) $event->id">
+        <flux:select.option :value="$event->slug">
             {{ $event->title }} ({{ $event->slug }}){{ $event->is_published ? '' : ' - NICHT VERÖFFENTLICHT' }}
         </flux:select.option>
     @endforeach

--- a/resources/views/components/stats.blade.php
+++ b/resources/views/components/stats.blade.php
@@ -1,5 +1,5 @@
 <div class="mt-9 first:mt-0">
-    <h2 class="text-xl font-semibold leading-6 text-hfm-dark dark:text-hfm-white">{{ $title }}</h2>
+    <flux:heading size="xl">{{ $title }}</flux:heading>
     <dl class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4">
         {{ $slot }}
     </dl>

--- a/resources/views/pages/admin/dashboard.blade.php
+++ b/resources/views/pages/admin/dashboard.blade.php
@@ -1,6 +1,21 @@
 @component('layouts.admin', ['title' => $greeting . Auth::user()->name])
 
     @section('content')
+        @php($routeParameters = ['anlass' => $selectedEventSlug ?? ''])
+
+        <form method="GET" action="{{ route('admin.dashboard') }}" class="flex justify-end">
+            <flux:field class="w-full sm:w-80">
+                <flux:label>Anlass</flux:label>
+                <flux:select name="anlass" onchange="this.form.submit()">
+                    <option value="" @selected($selectedEventSlug === null)>Alle Anlässe</option>
+                    @foreach ($events as $event)
+                        <option value="{{ $event->slug }}" @selected($selectedEventSlug === $event->slug)>
+                            {{ $event->title }} ({{ $event->slug }}){{ $event->is_published ? '' : ' - NICHT VERÖFFENTLICHT' }}
+                        </option>
+                    @endforeach
+                </flux:select>
+            </flux:field>
+        </form>
 
         <!-- Athlete -->
         <x-stats title="Sportler:innen">
@@ -8,21 +23,25 @@
                 title="Registriert"
                 :value="$athleteCount"
                 route="admin.athletes.index"
+                :route-parameters="$routeParameters"
             />
             <x-admin.stat-card
                 title="Verifiziert"
                 :value="$verifiedAthleteCount"
                 route="admin.athletes.index"
+                :route-parameters="$routeParameters"
             />
             <x-admin.stat-card
                 title="Durchschn. Runden"
                 :value="round($meanNumberOfRounds, 0)"
                 route="admin.athletes.index"
+                :route-parameters="$routeParameters"
             />
             <x-admin.stat-card
                 title="Durchschn. Spenden"
                 :value="round($meanNumberOfDonations, 0)"
                 route="admin.athletes.index"
+                :route-parameters="$routeParameters"
             />
         </x-stats>
 
@@ -32,16 +51,19 @@
                 title="Registriert"
                 :value="$donationCount"
                 route="admin.donations.index"
+                :route-parameters="$routeParameters"
             />
             <x-admin.stat-card
                 title="Verifiziert"
                 :value="$verifiedDonationCount"
                 route="admin.donations.index"
+                :route-parameters="$routeParameters"
             />
             <x-admin.stat-card
                 title="Durchschn. Betrag pro Runde"
                 :value="'Fr. '.round($meanDonationAmount, 2)"
                 route="admin.donations.index"
+                :route-parameters="$routeParameters"
             />
         </x-stats>
 
@@ -51,12 +73,14 @@
                 title="Erwartete Spenden"
                 :value="'Fr. '.round($expectedDonationAmount, 2)"
                 route="admin.donations.index"
+                :route-parameters="$routeParameters"
             />
             @foreach ($partners as $partner)
                 <x-admin.stat-card
                     title="{{ $partner->name }}"
                     :value="'Fr. '.round($estimatedAmounts[$partner->id] ?? 0, 2)"
                     route="admin.donations.index"
+                    :route-parameters="$routeParameters"
                 />
             @endforeach
         </x-stats>
@@ -67,12 +91,14 @@
                 title="Tatsächliche Spenden"
                 :value="'Fr. '.round($actualTotalAmount, 2)"
                 route="admin.donations.index"
+                :route-parameters="$routeParameters"
             />
             @foreach ($partners as $partner)
                 <x-admin.stat-card
                     title="{{ $partner->name }}"
                     :value="'Fr. '.round($actualAmounts[$partner->id] ?? 0, 2)"
                     route="admin.donations.index"
+                    :route-parameters="$routeParameters"
                 />
             @endforeach
         </x-stats>
@@ -83,11 +109,13 @@
                 title="Registriert"
                 :value="$donorCount"
                 route="admin.donors.index"
+                :route-parameters="$routeParameters"
             />
             <x-admin.stat-card
                 title="Durchschn. Spenden"
                 :value="round($meanNumberOfDonationsDonor, 1)"
                 route="admin.donors.index"
+                :route-parameters="$routeParameters"
             />
         </x-stats>
 

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,12 +1,13 @@
 <?php
 
+use App\Http\Controllers\Admin\DashboardController;
 use App\Http\Controllers\Admin\DonationEventSettingsController;
 use App\Http\Controllers\Admin\WeblingInterfaceTestPdfController;
 use App\Http\Controllers\AdminSessionController;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('auth:web')->group(function (): void {
-    Route::view('admin', 'pages.admin.dashboard')->name('admin.dashboard');
+    Route::get('admin', DashboardController::class)->name('admin.dashboard');
     Route::view('admin/anlaesse', 'pages.admin.donation-events')->name('admin.donation-events.index');
     Route::get('admin/anlaesse/neu', [DonationEventSettingsController::class, 'create'])->name('admin.donation-events.create');
     Route::get('admin/anlaesse/{donationEvent}/bearbeiten', [DonationEventSettingsController::class, 'edit'])->name('admin.donation-events.edit');

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -16,7 +16,6 @@ Route::middleware('auth:web')->group(function (): void {
     Route::view('admin/faqs', 'pages.admin.faqs')->name('admin.faqs.index');
     Route::view('admin/sportlerinnen', 'pages.admin.people', ['title' => 'Sportler:innen', 'role' => 'athlete'])->name('admin.athletes.index');
     Route::view('admin/spenderinnen', 'pages.admin.people', ['title' => 'Spender:innen', 'role' => 'donor'])->name('admin.donors.index');
-    Route::view('admin/externe-personen', 'pages.admin.people', ['title' => 'Sportler:innen', 'role' => 'athlete']);
     Route::view('admin/spenden', 'pages.admin.donations')->name('admin.donations.index');
     Route::view('admin/dateien', 'pages.admin.files')->name('admin.files.index');
     Route::view('admin/tools', 'pages.admin.tools')->name('admin.tools');

--- a/tests/Feature/Actions/GetDashboardDataActionTest.php
+++ b/tests/Feature/Actions/GetDashboardDataActionTest.php
@@ -95,3 +95,62 @@ it('builds dashboard data with expected aggregates', function (): void {
         ->and($data['greeting'] !== '')->toBeTrue();
 
 });
+
+it('scopes dashboard data and activities to an event', function (): void {
+    $selectedEvent = DonationEvent::factory()->year(2026)->create();
+    $otherEvent = DonationEvent::factory()->year(2025)->create();
+    $selectedPartner = Partner::factory()->create(['name' => 'Selected Partner']);
+    $otherPartner = Partner::factory()->create(['name' => 'Other Partner']);
+    $selectedEvent->partners()->attach($selectedPartner);
+    $otherEvent->partners()->attach($otherPartner);
+
+    $selectedAthlete = ExternalUser::factory()->create(['first_name' => 'Selected Athlete']);
+    $selectedRegistration = AthleteRegistration::factory()
+        ->forEvent($selectedEvent)
+        ->forExternalUser($selectedAthlete)
+        ->withPartner($selectedPartner)
+        ->verified()
+        ->create(['rounds_estimated' => 10, 'rounds_done' => 12]);
+    $selectedDonor = ExternalUser::factory()->create(['first_name' => 'Selected Donor']);
+    Donation::factory()
+        ->forPair($selectedDonor, $selectedRegistration)
+        ->create([
+            'amount_per_round' => 2,
+            'amount_min' => null,
+            'amount_max' => 30,
+            'verified' => true,
+        ]);
+
+    $otherAthlete = ExternalUser::factory()->create(['first_name' => 'Other Athlete']);
+    $otherRegistration = AthleteRegistration::factory()
+        ->forEvent($otherEvent)
+        ->forExternalUser($otherAthlete)
+        ->withPartner($otherPartner)
+        ->create(['rounds_estimated' => 100, 'rounds_done' => 100]);
+    $otherDonor = ExternalUser::factory()->create(['first_name' => 'Other Donor']);
+    Donation::factory()
+        ->forPair($otherDonor, $otherRegistration)
+        ->create(['amount_per_round' => 100, 'verified' => false]);
+
+    $data = app(GetDashboardDataAction::class)($selectedEvent);
+
+    expect($data['selectedEventSlug'])->toBe($selectedEvent->slug)
+        ->and($data['partners']->pluck('id')->all())->toBe([$selectedPartner->id])
+        ->and($data['athleteCount'])->toBe(1)
+        ->and($data['verifiedAthleteCount'])->toBe(1)
+        ->and($data['donorCount'])->toBe(1)
+        ->and($data['donationCount'])->toBe(1)
+        ->and($data['verifiedDonationCount'])->toBe(1)
+        ->and($data['meanNumberOfDonations'])->toBe(1.0)
+        ->and($data['meanNumberOfRounds'])->toBe(10.0)
+        ->and($data['meanNumberOfDonationsDonor'])->toBe(1.0)
+        ->and($data['meanDonationAmount'])->toBe(2.0)
+        ->and($data['expectedDonationAmount'])->toBe(20.0)
+        ->and($data['actualTotalAmount'])->toBe(24.0)
+        ->and($data['estimatedAmounts'])->toBe([$selectedPartner->id => 20.0])
+        ->and($data['actualAmounts'])->toBe([$selectedPartner->id => 24.0])
+        ->and(collect($data['mostRecentActivities'])->pluck('type')->unique()->sort()->values()->all())
+        ->toBe(['athlete_registration', 'donation', 'external_user'])
+        ->and(collect($data['mostRecentActivities'])->pluck('name')->implode(' '))
+        ->not->toContain('Other');
+});

--- a/tests/Feature/AdminDashboardTest.php
+++ b/tests/Feature/AdminDashboardTest.php
@@ -1,7 +1,10 @@
 <?php
 
+use App\Models\DonationEvent;
+use App\Models\ExternalUser;
 use App\Models\Partner;
 use App\Models\User;
+use App\Settings\EventSettings;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 use function Pest\Laravel\actingAs;
@@ -31,3 +34,50 @@ it('renders partner cards even when partner totals are missing', function () {
         ->assertSuccessful()
         ->assertSee('Test Partner');
 });
+
+it('defaults dashboard data and links to the current event', function (): void {
+    $currentEvent = DonationEvent::factory()->year(2026)->create(['is_published' => true]);
+    $otherEvent = DonationEvent::factory()->year(2025)->create(['is_published' => true]);
+    ExternalUser::factory()->asAthlete($currentEvent)->create();
+    ExternalUser::factory()->count(2)->asAthlete($otherEvent)->create();
+
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $currentEvent->id;
+    $settings->save();
+
+    actingAs(User::factory()->create());
+
+    get(route('admin.dashboard'))
+        ->assertSuccessful()
+        ->assertSee('value="'.$currentEvent->slug.'" selected', false)
+        ->assertSee('onchange="this.form.submit()"', false)
+        ->assertSee(route('admin.athletes.index', ['anlass' => $currentEvent->slug]), false)
+        ->assertSee('data-flux-timeline', false);
+});
+
+it('filters the dashboard by another event or all events', function (): void {
+    $currentEvent = DonationEvent::factory()->year(2026)->create(['is_published' => true]);
+    $otherEvent = DonationEvent::factory()->year(2025)->create(['is_published' => true]);
+
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $currentEvent->id;
+    $settings->save();
+
+    actingAs(User::factory()->create());
+
+    get(route('admin.dashboard', ['anlass' => $otherEvent->slug]))
+        ->assertSuccessful()
+        ->assertSee('value="'.$otherEvent->slug.'" selected', false)
+        ->assertSee(route('admin.donations.index', ['anlass' => $otherEvent->slug]), false);
+
+    get(route('admin.dashboard').'?anlass=')
+        ->assertSuccessful()
+        ->assertSee('value="" selected', false)
+        ->assertSee(route('admin.donors.index').'?anlass=', false);
+});
+
+it('rejects invalid dashboard event filters', function (string $eventSlug): void {
+    actingAs(User::factory()->create());
+
+    get(route('admin.dashboard', ['anlass' => $eventSlug]))->assertNotFound();
+})->with(['invalid', 'missing-event']);

--- a/tests/Feature/AdminEntryPointsTest.php
+++ b/tests/Feature/AdminEntryPointsTest.php
@@ -18,7 +18,7 @@ it('renders athlete and donor admin pages for authenticated users', function ():
         ->assertSee('Sportler:innen')
         ->assertSee('data-flux-icon', false);
     get('/admin/spenderinnen')->assertSuccessful()->assertSee('Spender:innen');
-    get('/admin/externe-personen')->assertSuccessful()->assertSee('Sportler:innen');
+    get('/admin/externe-personen')->assertNotFound();
 
     Livewire::test(AdminPersonTable::class, ['role' => 'athlete'])->assertStatus(200);
     Livewire::test(AdminPersonTable::class, ['role' => 'donor'])->assertStatus(200);

--- a/tests/Feature/Components/AdminDonationTableTest.php
+++ b/tests/Feature/Components/AdminDonationTableTest.php
@@ -29,7 +29,7 @@ it('filters donations by event and shows the event column', function (): void {
         ->assertSee('Anlass')
         ->assertSee($athlete2025->first_name)
         ->assertSee($athlete2026->first_name)
-        ->set('eventId', (string) $event2026->id)
+        ->set('eventSlug', $event2026->slug)
         ->assertDontSee($athlete2025->first_name)
         ->assertSee($athlete2026->first_name);
 });
@@ -43,7 +43,7 @@ it('clears donation selection when the event changes', function (): void {
 
     Livewire::test(AdminDonationTable::class)
         ->set('checkboxValues', [$donation->id])
-        ->set('eventId', (string) $event->id)
+        ->set('eventSlug', $event->slug)
         ->assertSet('checkboxValues', []);
 });
 
@@ -57,9 +57,9 @@ it('shows all donations again when the event filter is cleared', function (): vo
         ->create();
 
     Livewire::test(AdminDonationTable::class)
-        ->set('eventId', 'invalid')
+        ->set('eventSlug', 'invalid')
         ->assertDontSee($athlete->first_name)
         ->assertSee('Keine Spenden für diesen Anlass vorhanden.')
-        ->set('eventId', null)
+        ->set('eventSlug', null)
         ->assertSee($athlete->first_name);
 });

--- a/tests/Feature/Components/AdminPersonTableTest.php
+++ b/tests/Feature/Components/AdminPersonTableTest.php
@@ -3,6 +3,7 @@
 use App\Components\AdminPersonTable;
 use App\Models\DonationEvent;
 use App\Models\ExternalUser;
+use App\Settings\EventSettings;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\DB;
 use Livewire\Livewire;
@@ -67,7 +68,7 @@ it('filters unique athletes by event and shows their linked events', function ()
         ->assertSee($bothEvents->first_name)
         ->assertSee('2025')
         ->assertSee('2026')
-        ->set('eventId', (string) $event2026->id)
+        ->set('eventSlug', $event2026->slug)
         ->assertSee($bothEvents->first_name)
         ->assertDontSee($only2025->first_name);
 });
@@ -79,7 +80,7 @@ it('filters donors through the athlete registration event', function (): void {
     $donor2026 = ExternalUser::factory()->asDonor($event2026)->create(['first_name' => 'Donor 2026']);
 
     Livewire::test(AdminPersonTable::class, ['role' => 'donor'])
-        ->set('eventId', (string) $event2026->id)
+        ->set('eventSlug', $event2026->slug)
         ->assertSee($donor2026->first_name)
         ->assertDontSee($donor2025->first_name);
 });
@@ -90,7 +91,7 @@ it('clears stale selection when an event filter changes', function (): void {
 
     Livewire::test(AdminPersonTable::class, ['role' => 'athlete'])
         ->set('checkboxValues', [$athlete->id])
-        ->set('eventId', (string) $event->id)
+        ->set('eventSlug', $event->slug)
         ->assertSet('checkboxValues', []);
 });
 
@@ -98,7 +99,7 @@ it('returns no people for an invalid event filter', function (): void {
     $athlete = ExternalUser::factory()->asAthlete()->create(['first_name' => 'Visible Athlete']);
 
     Livewire::test(AdminPersonTable::class, ['role' => 'athlete'])
-        ->set('eventId', 'invalid')
+        ->set('eventSlug', 'invalid')
         ->assertDontSee($athlete->first_name)
         ->assertSee('Keine Sportler:innen für diesen Anlass vorhanden.');
 });
@@ -108,7 +109,55 @@ it('shows all people again when the event filter is cleared', function (): void 
     $athlete = ExternalUser::factory()->asAthlete($event)->create(['first_name' => 'Visible Athlete']);
 
     Livewire::test(AdminPersonTable::class, ['role' => 'athlete'])
-        ->set('eventId', (string) $event->id)
-        ->set('eventId', null)
+        ->set('eventSlug', $event->slug)
+        ->set('eventSlug', null)
         ->assertSee($athlete->first_name);
+});
+
+it('defaults athlete and donor tables to the current event', function (string $role): void {
+    $currentEvent = DonationEvent::factory()->year(2026)->create(['is_published' => true]);
+    $otherEvent = DonationEvent::factory()->year(2025)->create(['is_published' => true]);
+
+    $currentPerson = ExternalUser::factory()
+        ->{$role === 'athlete' ? 'asAthlete' : 'asDonor'}($currentEvent)
+        ->create(['first_name' => 'Current Person']);
+    $otherPerson = ExternalUser::factory()
+        ->{$role === 'athlete' ? 'asAthlete' : 'asDonor'}($otherEvent)
+        ->create(['first_name' => 'Other Person']);
+
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $currentEvent->id;
+    $settings->save();
+
+    Livewire::test(AdminPersonTable::class, ['role' => $role])
+        ->assertSet('eventSlug', $currentEvent->slug)
+        ->assertSee($currentPerson->first_name)
+        ->assertDontSee($otherPerson->first_name);
+})->with(['athlete', 'donor']);
+
+it('keeps an explicit event filter instead of the current event', function (): void {
+    $currentEvent = DonationEvent::factory()->year(2026)->create(['is_published' => true]);
+    $otherEvent = DonationEvent::factory()->year(2025)->create(['is_published' => true]);
+
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $currentEvent->id;
+    $settings->save();
+
+    Livewire::withQueryParams(['anlass' => $otherEvent->slug])
+        ->test(AdminPersonTable::class, ['role' => 'athlete'])
+        ->assertSet('eventSlug', $otherEvent->slug);
+});
+
+it('shows all people when the event filter is explicitly empty', function (): void {
+    $currentEvent = DonationEvent::factory()->year(2026)->create(['is_published' => true]);
+    ExternalUser::factory()->asAthlete($currentEvent)->create(['first_name' => 'Visible Athlete']);
+
+    $settings = app(EventSettings::class);
+    $settings->current_event_id = $currentEvent->id;
+    $settings->save();
+
+    Livewire::withQueryParams(['anlass' => ''])
+        ->test(AdminPersonTable::class, ['role' => 'athlete'])
+        ->assertSet('eventSlug', '')
+        ->assertSee('Visible Athlete');
 });

--- a/tests/Feature/Components/DatatableExportTest.php
+++ b/tests/Feature/Components/DatatableExportTest.php
@@ -70,7 +70,7 @@ it('exports selected donations as csv', function (): void {
     ]);
 
     Livewire::test(AdminDonationTable::class)
-        ->set('eventId', (string) $donationEvent->id)
+        ->set('eventSlug', $donationEvent->slug)
         ->set('checkboxValues', [$donation->id])
         ->call('exportSelected', 'csv')
         ->assertFileDownloaded();


### PR DESCRIPTION
Admin dashboard now defaults to current event and supports event-scoped metrics, links, and recent activity. Participant and donation tables use readable event slugs in their filters, while Flux UI replaces custom dashboard presentation and timeline markup.

## Details

- [GetDashboardDataAction.php](https://github.com/fuermenschen/hfm/blob/feat/dashboard-event-filter/app/Actions/GetDashboardDataAction.php) - scopes dashboard aggregates, partners, and activities by event.
- [DashboardController.php](https://github.com/fuermenschen/hfm/blob/feat/dashboard-event-filter/app/Http/Controllers/Admin/DashboardController.php) - resolves current event and slug query filter.
- [AdminPersonTable.php](https://github.com/fuermenschen/hfm/blob/feat/dashboard-event-filter/app/Components/AdminPersonTable.php) - defaults athlete and donor tables to current event.
- [activity-list-entry.blade.php](https://github.com/fuermenschen/hfm/blob/feat/dashboard-event-filter/resources/views/components/admin/activity-list-entry.blade.php) - renders Flux timeline activities.

## Notes

Dashboard filter submits automatically when selection changes. Explicit empty filter shows all events. Invalid event slugs return 404.

## Reviewer Setup

In this PR vs `origin/main`, changes were made in dashboard controllers/actions, Livewire datatables, Blade/Flux UI, tests, and Composer lint scripts. You likely need to run:

~~~sh
composer install
npm run build
php artisan boost:update
php artisan optimize:clear
~~~

Fixes #183
Fixes #184

---
**«Let all your things have their places; let each part of your business have its time.»**
_Benjamin Franklin_